### PR TITLE
shihshunyoung20211105

### DIFF
--- a/deepquantum/gates/qgate.py
+++ b/deepquantum/gates/qgate.py
@@ -369,7 +369,7 @@ class Circuit(object):
         """
         Pauli y
         """
-        return torch.tensor([[0,-1j],[1j,0]]) + 0j
+        return torch.tensor([[0,-1j], [1j,0]]) + 0j
 
     def _Hadamard(self):
         H = torch.sqrt(torch.tensor(0.5)) * torch.tensor([[1, 1], [1, -1]]) + 0j
@@ -380,7 +380,7 @@ class Circuit(object):
         rho为nqubit大小的密度矩阵，target为z门放置位置
 
         """
-        zgate = self.z_gate()
+        zgate = self._z_gate()
         H = self.gate_expand_1toN(zgate, nqubit, target)
         expecval = (rho @ H).trace()  # [-1,1]
         #expecval_real = (expecval.real + 1) / 2  # [0,1]


### PR DESCRIPTION
本次更新只涉及qgate.py文件

1，_y_gate方法中的注释有误，已从Pauli x改成Pauli y

2，expecval_ZI方法最终直接返回expecval_real = expecval.real，无需把期望值范围改到[0,1]，这反而容易让人误解，毕竟pauli z的期望值本来就是[-1,1]

3，expecval_ZI方法所有变量state改成rho，因为一般用rho表示密度矩阵，用state表示态矢

4，measure方法所有变量state改成rho，因为一般用rho表示密度矩阵，用state表示态矢

5，cnot方法中，_add_gate操作改成self._add_gate('cnot', [control_qubit, target_qubit],None)。cnot没有参数，所以传入None，which_qubit应该传入控制bit和目标bit组成的list

6，Hcz方法中，self._add_gate('cz', [control_qubit, target_qubit],None)。cz没有参数，所以传入None，which_qubit应该传入控制bit和目标bit组成的list

7，rxx方法中，只需用一个self._add_gate('rxx',[target_qubit01,target_qubit02], phi)，which_qubit应该传入控制bit和目标bit组成的list

8，ryy同7

9，rzz同7

10，Hcz方法改名为cz