### PR TITLE
Optimize 'get_matrix_state' to improve numerical stability (#17)

### DIFF
--- a/examples/gbs/boson_sampling/boson_sampling.ipynb
+++ b/examples/gbs/boson_sampling/boson_sampling.ipynb
@@ -62,13 +62,13 @@
     "输出的振幅可以表示成\n",
     "\n",
     "$$\n",
-    "\\langle n_1,n_2,...,n_N|W|\\psi\\rangle = \\frac{Per(U_{st})}{\\sqrt{m_1!...m_N!n_1...n_N！}}\n",
+    "\\langle n_1,n_2,...,n_N|W|\\psi\\rangle = \\frac{Per(U_{st})}{\\sqrt{m_1!...m_N!n_1...n_N!}}\n",
     "$$\n",
     "\n",
     "输出的概率可以写成\n",
     "\n",
     "$$\n",
-    "|\\langle n_1,n_2,...,n_N|W|\\psi\\rangle|^2 = \\frac{|Per(U_{st})|^2}{m_1!...m_N!n_1...n_N！}\n",
+    "|\\langle n_1,n_2,...,n_N|W|\\psi\\rangle|^2 = \\frac{|Per(U_{st})|^2}{m_1!...m_N!n_1...n_N!}\n",
     "$$\n",
     "\n",
     "这里的 $U_{st}$ 是通过对 $U$ 取行取列组合来得到，具体来说，根据输入 $|\\psi\\rangle = |m_1, m_2,...,m_N\\rangle$ 取对应的第 $i$ 行并且重复$m_i$ 次，如果 $m_i=0$ 则不取，根据输出 $|n_1,n_2,...,n_N\\rangle$ 取对应的第 $j$ 列并且重复 $m_j$ 次，如果 $m_j=0$ 则不取。 \n",
@@ -89,7 +89,7 @@
     "U_{1,3} & U_{2,3}\\end{pmatrix}\n",
     "$$\n",
     "\n",
-    "$U_{sub}$ 是对应的酉矩阵 $U$ 取第1，2行，第2，3列构成的子矩阵的转置。\n",
+    "$U_{sub}$ 是对应的酉矩阵 $U$ 取第1、2行和第2、3列构成的子矩阵的转置。\n",
     "\n",
     "\n",
     "\n",
@@ -141,7 +141,7 @@
    "outputs": [],
    "source": [
     "## 构建一个由ps门和bs门组成的4模线路，设置初态为[1,1,0,0]\n",
-    "import numpy as np \n",
+    "import numpy as np\n",
     "import deepquantum as dq"
    ]
   },

--- a/tests/test_photonic_gate.py
+++ b/tests/test_photonic_gate.py
@@ -22,3 +22,35 @@ def test_2_mode_squeezing_gate():
     assert torch.allclose(cov1, cov2, atol=1e-6)
     assert torch.allclose(mean1, mean2, atol=1e-6)
     assert torch.allclose(sym1, sym2, atol=1e-6)
+
+
+def test_squeezing_gate_numerical_stability():
+    cutoff = 128
+    r = 1
+    cir1 = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir1.s(0, r=r)
+    cir1.s(0, r=r)
+    cir1.to(torch.double)
+    state1 = cir1()
+
+    cir2 = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir2.s(0, r=2 * r)
+    cir2.to(torch.double)
+    state2 = cir2()
+    assert torch.allclose(state1, state2)
+
+
+def test_2_mode_squeezing_gate_numerical_stability():
+    cutoff = 64
+    r = 1
+    cir1 = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir1.s2([0,1], r=r)
+    cir1.s2([0,1], r=r)
+    cir1.to(torch.double)
+    state1 = cir1()
+
+    cir2 = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir2.s2([0,1], r=2 * r)
+    cir2.to(torch.double)
+    state2 = cir2()
+    assert torch.allclose(state1, state2)


### PR DESCRIPTION
- Fix #17. The results of squeezing gate are almost consistent with `Strawberry Fields` now

# Inconsistent Example

```python
nmode = 2
r = 1
for cutoff in [40, 70, 100]:
    prog = sf.Program(nmode)
    with prog.context as q:
        S2gate(r) | (q[0], q[1])
        S2gate(r) | (q[0], q[1])
    eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})
    result = eng.run(prog)

    cir = dq.QumodeCircuit(nmode, init_state='vac', cutoff=cutoff, basis=False)
    cir.s2([0,1], r)
    cir.s2([0,1], r)
    cir.to(torch.double)
    state = cir()

    print(abs((result.state.data - state.numpy())).max())
    print(abs(result.state.data).max(), state.abs().max())
```

```
4.618527782440651e-14
0.26580222874236326 tensor(0.2658, dtype=torch.float64)
1.9444332404611187e-08
0.26580222883407933 tensor(0.2658, dtype=torch.float64)
0.005547221558527327
0.6978525451826666 tensor(0.6982, dtype=torch.float64)
```

