### PR TITLE
Add delay loop and TDM module for Gaussian backend

### DIFF
--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -47,5 +47,5 @@ from .state import QubitState, MatrixProductState
 
 from .photonic import permanent, takagi, hafnian, torontonian
 from .photonic import FockState, GaussianState
-from .photonic import QumodeCircuit, Clements, GaussianBosonSampling
+from .photonic import QumodeCircuit, QumodeCircuitTDM, Clements, GaussianBosonSampling
 from .photonic import UnitaryMapper, UnitaryDecomposer, DrawClements

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -16,7 +16,7 @@ from . import state
 from . import torontonian_
 
 from .ansatz import Clements, GaussianBosonSampling, GBS_Graph
-from .circuit import QumodeCircuit
+from .circuit import QumodeCircuit, QumodeCircuitTDM
 from .decompose import UnitaryDecomposer
 from .draw import DrawClements
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -423,7 +423,7 @@ class QumodeCircuit(Operation):
                 idx_ = op.wires[0]
                 idx_para = k % len(op.inputs[1]) # periodic parameters
                 wires = [sublists[idx_][-2], sublists[idx_][-1]]
-                cir.bs(wires,[op.inputs[1][idx_para],0], encode=True)
+                cir.bs(wires,[op.inputs[1][idx_para], 0], encode=True)
                 cir.r(sublists[idx_][-2], op.inputs[2][idx_para], encode=True)
                 sublists_copy[idx_] = shift(sublists[idx_][:-1]) +  [sublists[idx_][-1]]  # consider shift (已解决), Rgate
         for mea in meas:
@@ -431,6 +431,7 @@ class QumodeCircuit(Operation):
             phi = mea.phi
             wire2 = sublists[wire][-1]
             cir.homodyne(wire2, phi)
+        cir.to(torch.double)
         self.unfold_circuit = cir
         return cir, sublists_copy
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -424,7 +424,7 @@ class QumodeCircuit(Operation):
                 idx_ = op.wires[0]
                 idx_para = k % len(op.inputs[1]) # periodic parameters
                 wires = [sublists[idx_][-2], sublists[idx_][-1]]
-                cir.bs(wires,[op.inputs[1][idx_para],0], encode=True)
+                cir.bs(wires,[op.inputs[1][idx_para], 0], encode=True)
                 cir.r(sublists[idx_][-2], op.inputs[2][idx_para], encode=True)
                 sublists_copy[idx_] = shift(sublists[idx_][:-1]) +  [sublists[idx_][-1]]  # consider shift (已解决), Rgate
         for mea in meas:
@@ -432,6 +432,7 @@ class QumodeCircuit(Operation):
             phi = mea.phi
             wire2 = sublists[wire][-1]
             cir.homodyne(wire2, phi)
+        cir.to(torch.double)
         self.unfold_circuit = cir
         return cir, sublists_copy
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -639,14 +639,16 @@ class QumodeCircuit(Operation):
             return
         assert len(data) >= self.ndata
         count = 0
-        if self._if_delayloop:
-            encoders = self._encoders_tdm
-        else:
-            encoders = self.encoders
-        for op in encoders:
+        for op in self.encoders:
             count_up = count + op.npara
             op.init_para(data[count:count_up])
             count = count_up
+        if self._if_delayloop:
+            count = 0
+            for op in self._encoders_tdm:
+                count_up = count + op.npara
+                op.init_para(data[count:count_up])
+                count = count_up
 
     def get_unitary(self) -> torch.Tensor:
         """Get the unitary matrix of the photonic quantum circuit."""

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -22,7 +22,7 @@ from .hafnian_ import hafnian
 from .measurement import Homodyne
 from .operation import Operation, Gate
 from .qmath import fock_combinations, permanent, product_factorial, sort_dict_fock_basis, sub_matrix
-from .qmath import photon_number_mean_var, quadrature_to_ladder, sample_sc_mcmc, lcm_multiple
+from .qmath import photon_number_mean_var, quadrature_to_ladder, sample_sc_mcmc, shift_fun
 from .state import FockState, GaussianState
 from .torontonian_ import torontonian
 from ..qmath import is_positive_definite
@@ -116,6 +116,8 @@ class QumodeCircuit(Operation):
         self._state_expand = None
         self._all_fock_basis = None
         self._if_delayloop = False
+        self._operators_tdm = nn.Sequential()
+        self._measurements_tdm = nn.ModuleList()
 
     def __add__(self, rhs: 'QumodeCircuit') -> 'QumodeCircuit':
         """Addition of the ``QumodeCircuit``.
@@ -359,8 +361,7 @@ class QumodeCircuit(Operation):
             state = GaussianState(state=state, nmode=self.nmode, cutoff=self.cutoff)
         state = [state.cov, state.mean]
         if self._if_delayloop:
-            self._forward_gaussian_delayloop_helper(data, state, k=1)
-            state = self._init_state_tdm
+            state = self._forward_gaussian_delayloop_helper(state)
         if data is None or data.ndim == 1:
             self.state = self._forward_helper_gaussian(data, state, stepwise)
             if self.state[0].ndim == 2:
@@ -377,10 +378,6 @@ class QumodeCircuit(Operation):
         if is_prob:
             self.state = self._forward_gaussian_prob(self.state[0], self.state[1], detector)
         return self.state
-
-    def _forward_gaussian_delayloop_helper(self, data, state, k):
-        """Forward pass for Gaussian backend with delay loops."""
-        raise NotImplementedError
 
     def _forward_helper_gaussian(
         self,
@@ -504,6 +501,111 @@ class QumodeCircuit(Operation):
                 dic_temp[s.item()].append(state)
             return list(dic_temp.values())
 
+    def _forward_gaussian_delayloop_helper(self, state: List):
+        """Forward pass helper function for Gaussian backend with delay loops."""
+        if len(self._operators_tdm) == 0:
+            cut_idx = [0]
+            ops = self.operators
+            temp_sum = 0
+            delay_dict = defaultdict(list)
+            for i in range(len(ops)):
+                op = ops[i]
+                if isinstance(op, Delay):
+                    delay_dict[op.wires[0]].append(op.n_tau)
+            for i in range(self.nmode):
+                temp = delay_dict[i]
+                if temp:
+                    cut_idx = cut_idx + [temp_sum+i, temp_sum+i+sum(temp)+1]
+                    temp_sum = temp_sum + sum(temp)
+            nmode = self.nmode + temp_sum
+            cut_idx = cut_idx + [nmode]
+            cut_idx = sorted(list(set(cut_idx)))
+            lst = list(range(nmode))
+            sublists = [lst[cut_idx[i]:cut_idx[i+1]] for i in range(len(cut_idx)-1)]
+            for i in range(self.nmode):
+                temp = delay_dict[i]
+                if temp:
+                    temp_rev = list(reversed(temp))
+                    temp_2 = sublists[i][:-1]
+                    temp_3 = [temp_2[sum(temp_rev[:k]):sum(temp_rev[:k+1])] for k in range(len(temp_rev))]
+                    sublists[i][:-1] = temp_3
+            self._sublists = deepcopy(sublists)
+            self._nmode_tdm = nmode
+            self._operators_tdm, self._measurements_tdm = self._construct_equal_circuit()
+
+        sublists = self._sublists
+        nmode = self._nmode_tdm
+        idx = torch.tensor([i[-1] for i in sublists])
+        idx = torch.cat([idx, idx + nmode])
+        cov_0, mean_0 = state
+        size = cov_0.size()
+        if size[-1] == self._nmode_tdm * 2:
+            init_state = state
+        else:
+            cov_1 = torch.stack([torch.eye(2 * nmode, dtype=cov_0.dtype, device=cov_0.device)] * size[0])
+            mean_1 = torch.stack([torch.zeros(2 * nmode, dtype=mean_0.dtype, device=mean_0.device)] * size[0])
+            mean_1 = mean_1.reshape(-1, 2 * nmode, 1)
+            cov_1[:, idx[:, None], idx] = cov_0
+            mean_1[:, idx] = mean_0
+            # cov_1 = cov_1.to(torch.double)
+            # mean_1 = mean_1.to(torch.double)
+            init_state = [cov_1, mean_1]
+        self._init_state_tdm = init_state
+        return init_state
+
+    def _construct_equal_circuit(self, k: int=1):
+        """Construct the equivalent circuit for the circuit with delay loop with shot=k."""
+        self._encoders_tdm = []
+        operators_tdm = nn.Sequential()
+        measurements_tdm = nn.ModuleList()
+        nmode = self._nmode_tdm
+        sublists = deepcopy(self._sublists)
+        ops = self.operators
+        meas = self.measurements
+        for i in range(len(ops)):
+            op = ops[i]
+            if not isinstance(op, Delay):
+                op_copy = deepcopy(op)
+                op_copy.nmode = nmode
+                wires = [ ]
+                for w in op.wires:
+                    wires.append(sublists[w][-1])
+                op_copy.wires = wires
+                if op in self.encoders:
+                    self._encoders_tdm.append(op_copy)
+                operators_tdm.append(op_copy)
+            else:
+                idx_ = op.wires[0]
+                sublists[idx_][-2] = shift_fun(sublists[idx_][-2], k-1) # inner shift
+                bs_wires = [sublists[idx_][-2][-1], sublists[idx_][-1]]
+                if op._type.lower() == 'bs':
+                    bs_theta = BeamSplitterTheta(inputs=op.theta, nmode=nmode, wires=bs_wires, cutoff=self.cutoff,
+                                                requires_grad=False, noise=self.noise, mu=None, sigma=None)
+                    r = PhaseShift(inputs=op.phi, nmode=nmode, wires=sublists[idx_][-2][-1], cutoff=self.cutoff,
+                                  requires_grad=False, noise=self.noise, mu=None, sigma=None, inv_mode=None)
+                    operators_tdm.append(bs_theta)
+                    operators_tdm.append(r)
+                    if op in self.encoders:
+                        self._encoders_tdm.append(bs_theta)
+                        self._encoders_tdm.append(r)
+                if op._type.lower() =='mzi':
+                    mzi = MZI(inputs=[op.theta, op.phi], nmode=nmode, wires=bs_wires, cutoff=self.cutoff,
+                             requires_grad=False, noise=self.noise, mu=None, sigma=None)
+                    operators_tdm.append(mzi)
+                    if op in self.encoders:
+                        self._encoders_tdm.append(mzi)
+                sublists[idx_] = shift_fun(sublists[idx_][:-1], 1) +  [sublists[idx_][-1]] # outer shift, only one step shift.
+        mea_wires = [ ]
+        for mea in meas:
+            wire = mea.wires[0]
+            mea_wires.append(wire)
+            wire2 = sublists[wire][-1]
+            phi = mea.phi
+            homodyne = Homodyne(phi=phi, nmode=nmode, wires=wire2)
+            measurements_tdm.append(homodyne)
+        operators_tdm.to(self.init_state.cov.dtype)
+        return [operators_tdm, measurements_tdm]
+
     def encode(self, data: Optional[torch.Tensor]) -> None:
         """Encode the input data into the photonic quantum circuit parameters.
 
@@ -521,6 +623,12 @@ class QumodeCircuit(Operation):
             count_up = count + op.npara
             op.init_para(data[count:count_up])
             count = count_up
+        if self._if_delayloop:
+            count = 0
+            for op in self._encoders_tdm:
+                count_up = count + op.npara
+                op.init_para(data[count:count_up])
+                count = count_up
 
     def get_unitary(self) -> torch.Tensor:
         """Get the unitary matrix of the photonic quantum circuit."""
@@ -1134,12 +1242,18 @@ class QumodeCircuit(Operation):
         if self.state is None:
             return
         if len(self.measurements) > 0:
+            if self._if_delayloop:
+                measurements = self._measurements_tdm
+                nmode = self._nmode_tdm
+            else:
+                measurements = self._measurements
+                nmode = self.nmode
             samples = []
             batch = self.state[0].shape[0]
-            cov  = torch.stack([self.state[0]] * shots).reshape(shots * batch, 2 * self.nmode, 2 * self.nmode)
-            mean = torch.stack([self.state[1]] * shots).reshape(shots * batch, 2 * self.nmode, 1)
+            cov  = torch.stack([self.state[0]] * shots).reshape(shots * batch, 2 * nmode, 2 * nmode)
+            mean = torch.stack([self.state[1]] * shots).reshape(shots * batch, 2 * nmode, 1)
             self.state_measured = [cov, mean]
-            for op_m in self.measurements:
+            for op_m in measurements:
                 self.state_measured = op_m(self.state_measured)
                 samples.append(op_m.samples.reshape(shots, batch, -1).permute(1, 0, 2))
             return torch.cat(samples, dim=-1).squeeze() # (batch, shots, nwire)
@@ -1700,6 +1814,27 @@ class QumodeCircuit(Operation):
                             requires_grad=False, noise=self.noise, mu=mu, sigma=sigma)
         self.measurements.append(homodyne)
 
+    def delay(
+        self,
+        wires: Optional[int] = None,
+        n_tau: int = 1,
+        inputs: Any = None,
+        encode: bool = False,
+        type: str = 'bs',
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a delay loop."""
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        requires_grad = not encode
+        delay = Delay(n_tau=n_tau, inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff,
+                      requires_grad=requires_grad, type=type, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(delay, encode=encode)
+        self._if_delayloop = True
+
 class QumodeCircuitTDM(QumodeCircuit):
     def __init__(
         self,
@@ -1720,181 +1855,99 @@ class QumodeCircuitTDM(QumodeCircuit):
                         cutoff=cutoff, backend=backend, basis=basis,
                         detector=detector, mps=mps, chi=chi, noise=noise,
                         mu=mu, sigma=sigma)
-
-    def delay(
+    def forward(
         self,
-        wires: int,
-        inputs: Any = None,
-        encode: bool = False, # 是否支持encode?
-        mu: Optional[float] = None,
-        sigma: Optional[float] = None
-    ) -> None:
-        """Add a delay loop."""
-        if mu is None:
-            mu = self.mu
-        if sigma is None:
-            sigma = self.sigma
-        delay = Delay(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, requires_grad=False)
-        self.add(delay, encode=False)
-        self._if_delayloop = True
-        if encode:
-            self.encoders.append(delay)
-            self.ndata = self.ndata + delay.npara
-
-    def measure_homodyne(self, shots: int = 1024):
-        assert self._if_delayloop, 'No delay loop here, use `QumodeCircuit` instead. '
-        samples = []
-        init_state = self._init_state_tdm
-        nmode = self._nmode_tdm
-        for i in range(1, shots+1):
-            self._operators_tdm, self._measurements_tdm = self._circuits_tdm[(i-1) % self._num_circuit_tdm]
-            assert len(self._measurements_tdm) > 0, 'No homodyne measurement here.'
-            self.state = self._forward_helper_gaussian(state=init_state)
-            if self.state[0].ndim == 2:
-                batch = 1
-            else:
-                batch = self.state[0].shape[0]
-            cov  = torch.stack([self.state[0]] * 1).reshape(1 * batch, 2 * nmode, 2 * nmode)
-            mean = torch.stack([self.state[1]] * 1).reshape(1 * batch, 2 * nmode, 1)
-            self.state_measured = [cov, mean]
-            sample_i = [ ]
-            for op_m in self._measurements_tdm:
-                self.state_measured = op_m(self.state_measured)
-                sample_i.append(op_m.samples.reshape(1, batch, -1).permute(1, 0, 2))
-            init_state = self.state_measured
-            sample_i = torch.cat(sample_i, dim=-1).squeeze()
-            samples.append(sample_i)
-        return torch.stack(samples)
-
-    def encode(self, data: Optional[torch.Tensor]) -> None:
-        """Encode the input data into the photonic quantum circuit parameters.
-
-        This method iterates over the ``encoders`` of the circuit and initializes their parameters
-        with the input data.
+        data: Optional[torch.Tensor] = None,
+        state: Any = None,
+        step: int = 1,
+        is_prob: Optional[bool] = None
+    ) -> Union[torch.Tensor, Dict, List[torch.Tensor]]:
+        """Perform a forward pass of the photonic quantum circuit and return the final-state-related result.
 
         Args:
-            data (torch.Tensor or None): The input data for the ``encoders``, must be a 1D tensor.
+            data (torch.Tensor or None, optional): The input data for the ``encoders``. Default: ``None``
+            state (Any, optional): The initial state for the photonic quantum circuit. Default: ``None``
+            step (int): The repeat step to envolve the circuits. Default: 1
+            is_prob (bool or None, optional): For Fock backend, whether to return probabilities or amplitudes.
+                For Gaussian backend, whether to return probabilities or the final Gaussian state.
+                For Fock backend with ``basis=True``, set ``None`` to return the unitary matrix. Default: ``None``
+        Returns:
+            Union[torch.Tensor, Dict, List[torch.Tensor]]: The result of the photonic quantum circuit after
+            applying the ``operators`` and ``measuremnets``.
         """
-        if data is None:
-            return
-        assert len(data) >= self.ndata
-        count = 0
-        for op in self.encoders:
-            count_up = count + op.npara
-            if isinstance(op, Delay):
-                len_ = len(op.inputs[1])
-                op.init_para([op.inputs[0], data[count:count_up][:len_], data[count:count_up][len_:]])
+        if self.backend == 'fock':
+            return self._forward_fock(data, state, is_prob) # XXX need update
+        elif self.backend == 'gaussian':
+            return self._forward_gaussian(data, state, step)
+    def _forward_gaussian(
+        self,
+        data: Optional[torch.Tensor] = None,
+        state: Any = None,
+        step: int = 1
+    ) -> Union[List[torch.Tensor], Dict]:
+        """Perform a forward pass based on the Gaussian backend.
+
+        Args:
+            data (torch.Tensor or None, optional): The input data for the ``encoders``. The data shape should be
+            (batch, step, nfeat), each step with data of the shape (batch, nfeat). Default: ``None``
+            state (Any, optional): The initial state for the photonic quantum circuit. Default: ``None``
+            step (int): The repeat step to envolve the circuits. Default: 1
+        Returns:
+            List[torch.Tensor]: The covariance matrix and displacement vector of the final state.
+        """
+        if state is None:
+            state = self.init_state
+            state = [state.cov, state.mean]
+        init_state = self._forward_gaussian_delayloop_helper(state)
+        init_state = GaussianState(state=init_state, nmode=self._nmode_tdm, cutoff=self.cutoff)
+        assert self._if_delayloop, 'No delay loop here'
+        assert len(self._measurements_tdm) > 0, 'No homodyne measurement here.'
+        assert len(self.measurements) == self.nmode, 'need all homodyne measurement here'
+        if data is not None:
+            size = data.size()
+            assert data.ndim == 3, 'the input data shape should be (batch, settings of parameters, nfeat) '
+        samples = []
+        for i in range(1, step+1):
+            if data is not None:
+                k = (i-1) % size[1] # periodic data encoding
+                data_i = data[:, k, :]
+                self.state = super()._forward_gaussian(data_i, init_state) # operators forward
             else:
-                op.init_para(data[count:count_up])
-            count = count_up
+                self.state = super()._forward_gaussian(state=init_state)
+            self.state = self._shift_state(self.state, i-1, back=True) # shift back to normal order
+            smaple_i = self.measure_homodyne(shots=1)
+            samples.append(smaple_i)
+            init_state = self.state_measured
+            init_state = self._shift_state(init_state, i) # state shift
+            init_state = GaussianState(state=init_state, nmode=self._nmode_tdm, cutoff=self.cutoff)
+        self.homodyne_samples = torch.stack(samples)
+        return self.state_measured
 
-    def _forward_gaussian_delayloop_helper(self, data, state, k):
-        """Forward pass for Gaussian backend with delay loops."""
-        # self.encode(data)
-        if k == 1:
-            delay_wires = []
-            cut_idx = [0]
-            ops = self.operators
-            temp_sum = 0
-            delay_dict = defaultdict(list)
-            num_paras = []
-            for i in range(len(ops)):
-                op = ops[i]
-                if isinstance(op, Delay):
-                    delay_dict[op.wires[0]].append(op.inputs[0].item())
-                    num_paras.append(len(op.inputs[1]))
-            self._num_circuit_tdm = lcm_multiple(torch.unique(torch.tensor(sum(list(delay_dict.values()),[]) + num_paras)))
-            for i in range(self.nmode):
-                temp = delay_dict[i]
-                if temp:
-                    cut_idx = cut_idx + [temp_sum+i, temp_sum+i+sum(temp)+1]
-                    temp_sum = temp_sum + sum(temp)
-            nmode = self.nmode + temp_sum
-            delay_wires = torch.tensor(delay_wires)
-            cut_idx = cut_idx + [nmode]
-            cut_idx = sorted(list(set(cut_idx)))
-            lst = list(range(nmode))
-            sublists = [lst[cut_idx[i]:cut_idx[i+1]] for i in range(len(cut_idx)-1)]
-            for i in range(self.nmode):
-                temp = delay_dict[i]
-                if temp:
-                    temp_rev = list(reversed(temp))
-                    temp_2 = sublists[i][:-1]
-                    temp_3 = [temp_2[sum(temp_rev[:k]):sum(temp_rev[:k+1])] for k in range(len(temp_rev))]
-                    sublists[i][:-1] = temp_3
-            self._sublists = deepcopy(sublists)
-            self._nmode_tdm = nmode
-            self._circuits_tdm = [ ]
-            for j in range(1, self._num_circuit_tdm+1):
-                self._circuits_tdm.append(self._construct_equal_circuit(j))
-            self._operators_tdm, self._measurements_tdm = self._circuits_tdm[0]
-
-        if k > 1:
-            sublists = deepcopy(self._sublists)
-        nmode = self._nmode_tdm
-        idx = torch.tensor([i[-1] for i in sublists])
-        idx = torch.cat([idx, idx + nmode])
-        cov_0, mean_0 = state
-        print(cov_0.dtype, mean_0.dtype)
-
-        size = cov_0.size()
-        if size[-1] == self._nmode_tdm * 2:
-            init_state = state
+    def _shift_state(self, state, k, back=False):
+        """Shift the state according to step k, which is equivalent to shift the corresponding wires of tdm circuits."""
+        cov, mean = state
+        cov_shift = cov.clone().detach()
+        mean_shift = mean.clone().detach()
+        sublists = self._sublists
+        if back:
+            for i in range(len(sublists)):
+                temp = sublists[i]
+                for j in range(len(temp)-1):
+                    temp2 = torch.tensor(temp[j])
+                    k = k % len(temp)
+                    temp2_shift = torch.tensor(temp[j][k:] + temp[j][:k])
+                    idx1 = torch.cat([temp2, temp2 + self._nmode_tdm]) # xxpp order
+                    idx2 = torch.cat([temp2_shift, temp2_shift + self._nmode_tdm])
+                    cov_shift[:, idx1[:, None], idx1] = cov[:, idx2[:, None], idx2]
+                    mean_shift[:, idx1] = mean[:, idx2]
         else:
-            cov_1 = torch.stack([torch.eye(2 * nmode, dtype=cov_0.dtype, device=cov_0.device)] * size[0])
-            mean_1 = torch.stack([torch.zeros(2 * nmode, dtype=mean_0.dtype, device=mean_0.device)] * size[0])
-            mean_1 = mean_1.reshape(-1, 2 * nmode, 1)
-            cov_1[:, idx[:, None], idx] = cov_0
-            mean_1[:, idx] = mean_0
-            cov_1 = cov_1.to(torch.double)
-            mean_1 = mean_1.to(torch.double)
-            init_state = [cov_1, mean_1]
-        self._init_state_tdm = init_state
-        self._operators_tdm, self._measurements_tdm = self._circuits_tdm[(k-1) % self._num_circuit_tdm]
-        return
-
-    def _construct_equal_circuit(self, k):
-        """Construct the equivalent circuit for the circuit with delay loop."""
-        def shift(a, step):
-            if len(a) <= 1:
-                return a
-            step = step % len(a)
-            return a[-step:] + a[:-step]
-        operators_tdm = nn.Sequential()
-        measurements_tdm = nn.ModuleList()
-        nmode = self._nmode_tdm
-        sublists = deepcopy(self._sublists)
-        ops = self.operators
-        meas = self.measurements
-        for i in range(len(ops)):
-            op = ops[i]
-            if not isinstance(op, Delay):
-                op_copy = deepcopy(op)
-                # op_copy.init_para([])
-                op_copy.nmode = nmode
-                wires = [ ]
-                for w in op.wires:
-                    wires.append(sublists[w][-1])
-                op_copy.wires = wires
-                operators_tdm.append(op_copy)
-            else:
-                idx_ = op.wires[0]
-                idx_para = (k-1) % len(op.inputs[1]) # periodic parameters
-                sublists[idx_][-2] = shift(sublists[idx_][-2], k-1) # inner shift
-
-                wires = [sublists[idx_][-2][-1], sublists[idx_][-1]]
-                bs_theta = BeamSplitterTheta(inputs=op.inputs[1][idx_para], nmode=nmode, wires=wires, cutoff=self.cutoff,
-                             requires_grad=None, noise=self.noise, mu=None, sigma=None)
-                r = PhaseShift(inputs=op.inputs[2][idx_para], nmode=nmode, wires=sublists[idx_][-2][-1], cutoff=self.cutoff,
-                       requires_grad=None, noise=self.noise, mu=None, sigma=None, inv_mode=None)
-                operators_tdm.append(bs_theta)
-                operators_tdm.append(r)
-                sublists[idx_] = shift(sublists[idx_][:-1], 1) +  [sublists[idx_][-1]] # outer shift, only one step shift.
-        for mea in meas:
-            wire = mea.wires[0]
-            wire2 = sublists[wire][-1]
-            phi = mea.phi
-            homodyne = Homodyne(phi=phi, nmode=nmode, wires=wire2)
-            measurements_tdm.append(homodyne)
-        operators_tdm.to(torch.double)
-        return [operators_tdm, measurements_tdm]
+            for i in range(len(sublists)):
+                temp = sublists[i]
+                for j in range(len(temp)-1):
+                    temp2 = torch.tensor(temp[j])
+                    temp2_shift = torch.tensor(shift_fun(temp[j], k))
+                    idx1 = torch.cat([temp2, temp2 + self._nmode_tdm]) # xxpp order
+                    idx2 = torch.cat([temp2_shift, temp2_shift + self._nmode_tdm])
+                    cov_shift[:, idx1[:, None], idx1] = cov[:, idx2[:, None], idx2]
+                    mean_shift[:, idx1] = mean[:, idx2]
+        return [cov_shift, mean_shift]

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -17,7 +17,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 from .decompose import UnitaryDecomposer
 from .draw import DrawCircuit
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate
-from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum
+from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum, Delay
 from .hafnian_ import hafnian
 from .measurement import Homodyne
 from .operation import Operation, Gate
@@ -1659,3 +1659,22 @@ class QumodeCircuit(Operation):
         homodyne = Homodyne(phi=phi, nmode=self.nmode, wires=wires, cutoff=self.cutoff, eps=eps,
                             requires_grad=False, noise=self.noise, mu=mu, sigma=sigma)
         self.measurements.append(homodyne)
+
+    def delay(
+        self,
+        wires: int,
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a rotation gate."""
+        requires_grad = False
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        delay = Delay(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff)
+        self.add(delay, encode=encode)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -519,7 +519,7 @@ class QumodeCircuit(Operation):
                 dic_temp[s.item()].append(state)
             return list(dic_temp.values())
 
-    def _prepare_unroll_dict(self) -> Dict[List]:
+    def _prepare_unroll_dict(self) -> Dict[int, List]:
         """Create a dictionary that maps spatial modes to concurrent modes."""
         if self._unroll_dict is None:
             ntau_dict = defaultdict(list)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -383,17 +383,18 @@ class QumodeCircuit(Operation):
         delay_wires = [ ]
         cut_idx = [0]
         ops = self.operators
-        nmode = self.nmode
+        temp_sum = 0
         for i in range(len(ops)):
             op = ops[i]
             if isinstance(op, Delay):
                 delay_wires.append(op.wires[0])
-                cut_idx = cut_idx + [int(op.wires[0]), int(op.wires[0])+int(op.inputs[0])+1]
-                nmode = nmode + int(op.inputs[0])
+                cut_idx = cut_idx + [temp_sum+int(op.wires[0]), temp_sum+int(op.wires[0])+int(op.inputs[0])+1]
+                temp_sum = temp_sum + int(op.inputs[0])
+        nmode = self.nmode + temp_sum
         delay_wires = torch.tensor(delay_wires)
         assert torch.equal(torch.unique(delay_wires), delay_wires), 'single wire with multiple delay loops is not allowed'
         cut_idx = cut_idx + [nmode]
-        cut_idx = list(set(cut_idx))
+        cut_idx = sorted(list(set(cut_idx)))
         lst = list(range(nmode))
         sublists = [lst[cut_idx[i]:cut_idx[i+1]] for i in range(len(cut_idx)-1)]
         cir = self._construct_equal_circuit(nmode=nmode, init_state='vac', sublists=sublists, k=0)[0]
@@ -401,7 +402,7 @@ class QumodeCircuit(Operation):
         return cir()
 
     def _construct_equal_circuit(self, nmode, init_state, sublists, k):
-        """Construct the equivalent circuit for the circuit including delay loop."""
+        """Construct the equivalent circuit for the circuit with delay loop."""
         def shift(a):
             if len(a) <=1:
                 return a
@@ -418,7 +419,7 @@ class QumodeCircuit(Operation):
                 wires = [ ]
                 for w in op.wires:
                     wires.append(sublists[w][-1])
-                op_copy.wires = wires # consider 2 wires case, 可能跨BS操作, draw BS (已解决)
+                op_copy.wires = wires
                 cir.add(op_copy)
             else:
                 idx_ = op.wires[0]
@@ -426,13 +427,13 @@ class QumodeCircuit(Operation):
                 wires = [sublists[idx_][-2], sublists[idx_][-1]]
                 cir.bs(wires,[op.inputs[1][idx_para], 0], encode=True)
                 cir.r(sublists[idx_][-2], op.inputs[2][idx_para], encode=True)
-                sublists_copy[idx_] = shift(sublists[idx_][:-1]) +  [sublists[idx_][-1]]  # consider shift (已解决), Rgate
+                sublists_copy[idx_] = shift(sublists[idx_][:-1]) +  [sublists[idx_][-1]]
         for mea in meas:
             wire = mea.wires[0]
             phi = mea.phi
             wire2 = sublists[wire][-1]
             cir.homodyne(wire2, phi)
-        cir.to(torch.double)
+        cir.to(next(ops.buffers()).dtype)
         self.unfold_circuit = cir
         return cir, sublists_copy
 
@@ -1176,12 +1177,12 @@ class QumodeCircuit(Operation):
             return
         if self._if_delayloop:
             samples = []
-            init_state = 'vac'    # initial state expand
+            init_state = 'vac'    # XXX initial state expand
             nmode = self.unfold_circuit.nmode
             sublists = self._sublists
             for i in range(0, shots):
                 temp = self._construct_equal_circuit(nmode, init_state, sublists, i)
-                cir = temp[0]    # try encoding
+                cir = temp[0]    # XXX try encoding
                 cir()
                 sample_i = self.unfold_circuit.measure_homodyne(shots=1)
                 init_state = self.unfold_circuit.state_measured

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -17,7 +17,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 from .decompose import UnitaryDecomposer
 from .draw import DrawCircuit
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate
-from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum
+from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum, Delay
 from .hafnian_ import hafnian
 from .measurement import Homodyne
 from .operation import Operation, Gate
@@ -1669,3 +1669,22 @@ class QumodeCircuit(Operation):
         homodyne = Homodyne(phi=phi, nmode=self.nmode, wires=wires, cutoff=self.cutoff, eps=eps,
                             requires_grad=False, noise=self.noise, mu=mu, sigma=sigma)
         self.measurements.append(homodyne)
+
+    def delay(
+        self,
+        wires: int,
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a rotation gate."""
+        requires_grad = False
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        delay = Delay(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff)
+        self.add(delay, encode=encode)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -6,7 +6,7 @@ import itertools
 import random
 import warnings
 from collections import defaultdict, Counter
-from copy import copy
+from copy import copy, deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -115,6 +115,7 @@ class QumodeCircuit(Operation):
         self._nphoton = None
         self._state_expand = None
         self._all_fock_basis = None
+        self._if_delayloop = False
 
     def __add__(self, rhs: 'QumodeCircuit') -> 'QumodeCircuit':
         """Addition of the ``QumodeCircuit``.
@@ -357,6 +358,9 @@ class QumodeCircuit(Operation):
         elif not isinstance(state, GaussianState):
             state = GaussianState(state=state, nmode=self.nmode, cutoff=self.cutoff)
         state = [state.cov, state.mean]
+        if self._if_delayloop:
+            self.state = self._forward_gaussian_delayloop()
+            return self.state
         if data is None or data.ndim == 1:
             self.state = self._forward_helper_gaussian(data, state, stepwise)
             if self.state[0].ndim == 2:
@@ -373,6 +377,63 @@ class QumodeCircuit(Operation):
         if is_prob:
             self.state = self._forward_gaussian_prob(self.state[0], self.state[1], detector)
         return self.state
+
+    def _forward_gaussian_delayloop(self):
+        """Forward pass for Gaussian backend with delay loop."""
+        delay_wires = [ ]
+        cut_idx = [0]
+        ops = self.operators
+        nmode = self.nmode
+        for i in range(len(ops)):
+            op = ops[i]
+            if isinstance(op, Delay):
+                delay_wires.append(op.wires[0])
+                cut_idx = cut_idx + [int(op.wires[0]), int(op.wires[0])+int(op.inputs[0])+1]
+                nmode = nmode + int(op.inputs[0])
+        delay_wires = torch.tensor(delay_wires)
+        assert torch.equal(torch.unique(delay_wires), delay_wires), 'single wire with multiple delay loops is not allowed'
+        cut_idx = cut_idx + [nmode]
+        cut_idx = list(set(cut_idx))
+        lst = list(range(nmode))
+        sublists = [lst[cut_idx[i]:cut_idx[i+1]] for i in range(len(cut_idx)-1)]
+        cir = self._construct_equal_circuit(nmode=nmode, init_state='vac', sublists=sublists, k=0)[0]
+        self._sublists = sublists
+        return cir()
+
+    def _construct_equal_circuit(self, nmode, init_state, sublists, k):
+        """Construct the equivalent circuit for the circuit including delay loop."""
+        def shift(a):
+            if len(a) <=1:
+                return a
+            return a[-1:] + a[:-1]
+        cir = QumodeCircuit(nmode=nmode, init_state=init_state, cutoff=self.cutoff, backend='gaussian', basis=True)
+        ops = self.operators
+        meas = self.measurements
+        sublists_copy = deepcopy(sublists)
+        for i in range(len(ops)):
+            op = ops[i]
+            if not isinstance(op, Delay):
+                op_copy = deepcopy(op)
+                op_copy.nmode = nmode
+                wires = [ ]
+                for w in op.wires:
+                    wires.append(sublists[w][-1])
+                op_copy.wires = wires # consider 2 wires case, 可能跨BS操作, draw BS (已解决)
+                cir.add(op_copy)
+            else:
+                idx_ = op.wires[0]
+                idx_para = k % len(op.inputs[1]) # periodic parameters
+                wires = [sublists[idx_][-2], sublists[idx_][-1]]
+                cir.bs(wires,[op.inputs[1][idx_para],0], encode=True)
+                cir.r(sublists[idx_][-2], op.inputs[2][idx_para], encode=True)
+                sublists_copy[idx_] = shift(sublists[idx_][:-1]) +  [sublists[idx_][-1]]  # consider shift (已解决), Rgate
+        for mea in meas:
+            wire = mea.wires[0]
+            phi = mea.phi
+            wire2 = sublists[wire][-1]
+            cir.homodyne(wire2, phi)
+        self.unfold_circuit = cir
+        return cir, sublists_copy
 
     def _forward_helper_gaussian(
         self,
@@ -1112,6 +1173,21 @@ class QumodeCircuit(Operation):
         assert self.backend == 'gaussian'
         if self.state is None:
             return
+        if self._if_delayloop:
+            samples = []
+            init_state = 'vac'    # initial state expand
+            nmode = self.unfold_circuit.nmode
+            sublists = self._sublists
+            for i in range(0, shots):
+                temp = self._construct_equal_circuit(nmode, init_state, sublists, i)
+                cir = temp[0]    # try encoding
+                cir()
+                sample_i = self.unfold_circuit.measure_homodyne(shots=1)
+                init_state = self.unfold_circuit.state_measured
+                sublists = temp[1]
+                samples.append(sample_i)
+            return torch.stack(samples)
+
         if len(self.measurements) > 0:
             samples = []
             batch = self.state[0].shape[0]
@@ -1678,13 +1754,12 @@ class QumodeCircuit(Operation):
         mu: Optional[float] = None,
         sigma: Optional[float] = None
     ) -> None:
-        """Add a rotation gate."""
+        """Add a delay loop."""
         requires_grad = False
-        if inputs is not None:
-            requires_grad = False
         if mu is None:
             mu = self.mu
         if sigma is None:
             sigma = self.sigma
-        delay = Delay(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff)
-        self.add(delay, encode=encode)
+        delay = Delay(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, requires_grad=requires_grad)
+        self.add(delay, encode=False)
+        self._if_delayloop = True

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1835,7 +1835,7 @@ class QumodeCircuit(Operation):
     def homodyne_x(
         self,
         wires: Optional[int] = None,
-        eps: float = 2e-4,
+        eps: float = 1e-6,
         mu: Optional[float] = None,
         sigma: Optional[float] = None
     ) -> None:
@@ -1853,7 +1853,7 @@ class QumodeCircuit(Operation):
     def homodyne_p(
         self,
         wires: Optional[int] = None,
-        eps: float = 2e-4,
+        eps: float = 1e-6,
         mu: Optional[float] = None,
         sigma: Optional[float] = None
     ) -> None:

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1811,7 +1811,7 @@ class QumodeCircuit(Operation):
         self,
         wires: Optional[int] = None,
         phi: Any = None,
-        eps: float = 2e-4,
+        eps: float = 1e-6,
         encode: bool = False,
         mu: Optional[float] = None,
         sigma: Optional[float] = None

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -372,14 +372,11 @@ class QumodeCircuit(Operation):
         if state is None:
             state = self.init_state
         elif not isinstance(state, GaussianState):
+            nmode = self.nmode
             if self._nmode_tdm is not None:
                 if isinstance(state, list):
-                    nmode = state[0].size()[-1] // 2
-                    assert nmode == self.nmode or nmode == self._nmode_tdm
-                else:
-                    nmode = self.nmode
-            else:
-                nmode = self.nmode
+                    if state[0].size()[-1] // 2 == self._nmode_tdm:
+                        nmode = self._nmode_tdm
             state = GaussianState(state=state, nmode=nmode, cutoff=self.cutoff)
         state = [state.cov, state.mean]
         if self._if_delayloop:

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -11,7 +11,7 @@ import svgwrite
 from matplotlib import patches
 from torch import nn
 
-from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterSingle, UAnyGate, Squeezing, Squeezing2, Displacement
+from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterSingle, UAnyGate, Squeezing, Squeezing2, Displacement, Delay
 from .measurement import Homodyne
 
 info_dic = {'PS': ['teal', 0],
@@ -109,6 +109,14 @@ class DrawCircuit():
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:
                     depth[i] = depth[i]+1
+            elif isinstance(op, Delay):
+                name_ = ''
+                order = depth[op.wires[0]]
+                self.draw_sq(order, op.wires, r, theta, name_, delay=True)
+                order_dic[order] = order_dic[order] + op.wires
+                for i in op.wires:
+                    depth[i] = depth[i]+1
+
         if len(self.mea) > 0:
             for mea in self.mea:
                 if isinstance(mea, Homodyne):
@@ -213,30 +221,32 @@ class DrawCircuit():
         self.draw_.add(self.draw_.text('ϕ ='+str(np.round(phi,3)), insert=(x+55, y_up*30+20), font_size=7))
 
 
-    def draw_sq(self, order, wires, r, theta, name=None):
+    def draw_sq(self, order, wires, r, theta, name=None, delay=False):
         """
         Draw squeezing gate, displacement gate.
         """
         x = 90 * order + 40
         y_up = wires[0]
-        # y_down = wires[1]
         for i in range(len(wires)):
             wire_i = wires[i]
             self.draw_.add(self.draw_.polyline(points=[(x, wire_i*30+30), (x+90, wire_i*30+30)],
                                           fill='none', stroke='black', stroke_width=2))
-        fill_c = info_dic[name][0]
-        shift= info_dic[name][1]
+        if delay: # delay loop
+           self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
+        else: # squeezing gate
+            fill_c = info_dic[name][0]
+            shift= info_dic[name][1]
 
-        if len(wires)==1:
-            height = 12
-        if len(wires)==2:
-            height = 12*3+3
+            if len(wires)==1:
+                height = 12
+            if len(wires)==2:
+                height = 12*3+3
 
-        self.draw_.add(self.draw_.rect(insert=(x+42.5, y_up*30+25), size=(10, height), rx=0, ry=0,
-                                       fill=fill_c, stroke='black', stroke_width=1.5))
-        self.draw_.add(self.draw_.text(name, insert=(x+40+shift, y_up*30+20), font_size=9))
-        self.draw_.add(self.draw_.text('r ='+str(np.round(r,3)), insert=(x+55, y_up*30+18), font_size=7))
-        self.draw_.add(self.draw_.text('θ ='+str(np.round(theta,3)), insert=(x+55, y_up*30+24), font_size=7))
+            self.draw_.add(self.draw_.rect(insert=(x+42.5, y_up*30+25), size=(10, height), rx=0, ry=0,
+                                        fill=fill_c, stroke='black', stroke_width=1.5))
+            self.draw_.add(self.draw_.text(name, insert=(x+40+shift, y_up*30+20), font_size=9))
+            self.draw_.add(self.draw_.text('r ='+str(np.round(r,3)), insert=(x+55, y_up*30+18), font_size=7))
+            self.draw_.add(self.draw_.text('θ ='+str(np.round(theta,3)), insert=(x+55, y_up*30+24), font_size=7))
 
     def draw_any(self, order, wires, name, para_dict=None):
         """

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -105,14 +105,14 @@ class DrawCircuit():
                     name_ = 'S'
                 else:
                     name_ = 'D'
-                self.draw_sq(order, op.wires, r, theta, name_)
+                self.draw_sq(order, op.wires, r, theta, name=name_)
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:
                     depth[i] = depth[i]+1
             elif isinstance(op, Delay):
                 name_ = ''
                 order = depth[op.wires[0]]
-                self.draw_sq(order, op.wires, r, theta, name_, delay=True)
+                self.draw_sq(order, op.wires, inputs=op.inputs, name=name_, delay=True)
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:
                     depth[i] = depth[i]+1
@@ -155,20 +155,22 @@ class DrawCircuit():
         """
         x = 90 * order + 40
         y_up = wires[0]
-        # y_down = wires[1]
-        self.draw_.add(self.draw_.polyline(points=[(x, y_up*30+30), (x+30, y_up*30+30),
-                                                   (x+60, y_up*30+30+30), (x+90, y_up*30+30+30)],
+        y_down = wires[1]
+        y_delta = abs(y_down - y_up)
+        shift = -10
+        self.draw_.add(self.draw_.polyline(points=[(x, y_up*30+30), (x+30+shift, y_up*30+30), # need shift
+                                                   (x+60+shift, y_up*30+30+30*y_delta), (x+90, y_up*30+30+30*y_delta)],
                                            fill='none', stroke='black', stroke_width=2))
-        self.draw_.add(self.draw_.polyline(points=[(x, y_up*30+30+30), (x+30, y_up*30+30+30),
-                                                   (x+60, y_up*30+30), (x+90, y_up*30+30)],
+        self.draw_.add(self.draw_.polyline(points=[(x, y_up*30+30+30*y_delta), (x+30+shift, y_up*30+30+30*y_delta),
+                                                   (x+60+shift, y_up*30+30), (x+90, y_up*30+30)],
                                            fill='none', stroke='black', stroke_width=2))
-        self.draw_.add(self.draw_.text(name, insert=(x+40-(len(name)-2)*3, y_up*30+25), font_size=9))
+        self.draw_.add(self.draw_.text(name, insert=(x+40-(len(name)-2)*3+shift, y_up*30+25), font_size=9))
         self.draw_.add(self.draw_.text('θ ='+ str(np.round(theta,3)),
-                                       insert=(x+55, y_up*30+30+20-6),
+                                       insert=(x+55+shift, y_up*30+30+20-6),
                                        font_size=7))
         if phi is not None:
             self.draw_.add(self.draw_.text('ϕ ='+ str(np.round(phi,3)),
-                                           insert=(x+55, y_up*30+30+26-6),
+                                           insert=(x+55+shift, y_up*30+30+26-6),
                                            font_size=7))
 
     def draw_ps(self, order, wires, theta=0, name=None):
@@ -221,7 +223,7 @@ class DrawCircuit():
         self.draw_.add(self.draw_.text('ϕ ='+str(np.round(phi,3)), insert=(x+55, y_up*30+20), font_size=7))
 
 
-    def draw_sq(self, order, wires, r, theta, name=None, delay=False):
+    def draw_sq(self, order, wires, r=None, theta=None, inputs=None, name=None, delay=False):
         """
         Draw squeezing gate, displacement gate.
         """
@@ -232,7 +234,11 @@ class DrawCircuit():
             self.draw_.add(self.draw_.polyline(points=[(x, wire_i*30+30), (x+90, wire_i*30+30)],
                                           fill='none', stroke='black', stroke_width=2))
         if delay: # delay loop
-           self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
+            self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
+            self.draw_.add(self.draw_.text('N ='+str(inputs[0].tolist()), insert=(x+40, y_up*30+18), font_size=5))
+            self.draw_.add(self.draw_.text('bs_θ ='+str(np.round(inputs[1].tolist(),2)), insert=(x+58, y_up*30+18), font_size=6))
+            self.draw_.add(self.draw_.text('r_θ ='+str(np.round(inputs[2].tolist(),2)), insert=(x+58, y_up*30+24), font_size=6))
+
         else: # squeezing gate
             fill_c = info_dic[name][0]
             shift= info_dic[name][1]

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -112,7 +112,8 @@ class DrawCircuit():
             elif isinstance(op, Delay):
                 name_ = ''
                 order = depth[op.wires[0]]
-                self.draw_sq(order, op.wires, inputs=op.inputs, name=name_, delay=True)
+                inputs = [op.n_tau, op.theta, op.phi]
+                self.draw_sq(order, op.wires, inputs=inputs, name=name_, delay=True)
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:
                     depth[i] = depth[i]+1
@@ -235,9 +236,9 @@ class DrawCircuit():
                                           fill='none', stroke='black', stroke_width=2))
         if delay: # delay loop
             self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
-            self.draw_.add(self.draw_.text('N ='+str(inputs[0].tolist()), insert=(x+40, y_up*30+18), font_size=5))
-            self.draw_.add(self.draw_.text('bs_θ ='+str(np.round(inputs[1].tolist(),2)), insert=(x+58, y_up*30+18), font_size=6))
-            self.draw_.add(self.draw_.text('r_θ ='+str(np.round(inputs[2].tolist(),2)), insert=(x+58, y_up*30+24), font_size=6))
+            self.draw_.add(self.draw_.text('N ='+str(inputs[0]), insert=(x+40, y_up*30+18), font_size=5))
+            self.draw_.add(self.draw_.text('θ ='+str(np.round(inputs[1].tolist(),2)), insert=(x+58, y_up*30+18), font_size=6))
+            self.draw_.add(self.draw_.text('ϕ ='+str(np.round(inputs[2].tolist(),2)), insert=(x+58, y_up*30+24), font_size=6))
 
         else: # squeezing gate
             fill_c = info_dic[name][0]

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -225,7 +225,7 @@ class DrawCircuit():
 
     def draw_sq(self, order, wires, r=None, theta=None, inputs=None, name=None, delay=False):
         """
-        Draw squeezing gate, displacement gate.
+        Draw squeezing gate, displacement gate, delay loop.
         """
         x = 90 * order + 40
         y_up = wires[0]

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -113,7 +113,7 @@ class DrawCircuit():
                 name_ = ''
                 order = depth[op.wires[0]]
                 inputs = [op.ntau, op.theta, op.phi]
-                self.draw_sq(order, op.wires, inputs=inputs, name=name_, delay=True)
+                self.draw_delay(order, op.wires, inputs=inputs)
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:
                     depth[i] = depth[i]+1
@@ -224,7 +224,7 @@ class DrawCircuit():
         self.draw_.add(self.draw_.text('ϕ ='+str(np.round(phi,3)), insert=(x+55, y_up*30+20), font_size=7))
 
 
-    def draw_sq(self, order, wires, r=None, theta=None, inputs=None, name=None, delay=False):
+    def draw_sq(self, order, wires, r=None, theta=None, name=None):
         """
         Draw squeezing gate, displacement gate, delay loop.
         """
@@ -233,27 +233,35 @@ class DrawCircuit():
         for i in range(len(wires)):
             wire_i = wires[i]
             self.draw_.add(self.draw_.polyline(points=[(x, wire_i*30+30), (x+90, wire_i*30+30)],
-                                          fill='none', stroke='black', stroke_width=2))
-        if delay: # delay loop
-            self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
-            self.draw_.add(self.draw_.text('N ='+str(inputs[0]), insert=(x+40, y_up*30+18), font_size=5))
-            self.draw_.add(self.draw_.text('θ ='+str(np.round(inputs[1].tolist(),2)), insert=(x+58, y_up*30+18), font_size=6))
-            self.draw_.add(self.draw_.text('ϕ ='+str(np.round(inputs[2].tolist(),2)), insert=(x+58, y_up*30+24), font_size=6))
+                                               fill='none', stroke='black', stroke_width=2))
+        fill_c = info_dic[name][0]  # squeezing gate or displacement gate
+        shift= info_dic[name][1]
 
-        else: # squeezing gate
-            fill_c = info_dic[name][0]
-            shift= info_dic[name][1]
+        if len(wires)==1:
+            height = 12
+        if len(wires)==2:
+            height = 12*3+3
 
-            if len(wires)==1:
-                height = 12
-            if len(wires)==2:
-                height = 12*3+3
+        self.draw_.add(self.draw_.rect(insert=(x+42.5, y_up*30+25), size=(10, height), rx=0, ry=0,
+                                    fill=fill_c, stroke='black', stroke_width=1.5))
+        self.draw_.add(self.draw_.text(name, insert=(x+40+shift, y_up*30+20), font_size=9))
+        self.draw_.add(self.draw_.text('r ='+str(np.round(r,3)), insert=(x+55, y_up*30+18), font_size=7))
+        self.draw_.add(self.draw_.text('θ ='+str(np.round(theta,3)), insert=(x+55, y_up*30+24), font_size=7))
 
-            self.draw_.add(self.draw_.rect(insert=(x+42.5, y_up*30+25), size=(10, height), rx=0, ry=0,
-                                        fill=fill_c, stroke='black', stroke_width=1.5))
-            self.draw_.add(self.draw_.text(name, insert=(x+40+shift, y_up*30+20), font_size=9))
-            self.draw_.add(self.draw_.text('r ='+str(np.round(r,3)), insert=(x+55, y_up*30+18), font_size=7))
-            self.draw_.add(self.draw_.text('θ ='+str(np.round(theta,3)), insert=(x+55, y_up*30+24), font_size=7))
+    def draw_delay(self, order, wires, inputs=None):
+        """
+        Draw delay loop.
+        """
+        x = 90 * order + 40
+        y_up = wires[0]
+        for i in range(len(wires)):
+            wire_i = wires[i]
+            self.draw_.add(self.draw_.polyline(points=[(x, wire_i*30+30), (x+90, wire_i*30+30)],
+                                               fill='none', stroke='black', stroke_width=2))
+        self.draw_.add(self.draw_.circle(center=(x+46, y_up*30+25-4), r=9, stroke='black', fill='white', stroke_width=1.2))
+        self.draw_.add(self.draw_.text('N ='+str(inputs[0]), insert=(x+40, y_up*30+18), font_size=5))
+        self.draw_.add(self.draw_.text('θ ='+str(np.round(inputs[1].tolist(),2)), insert=(x+58, y_up*30+18), font_size=6))
+        self.draw_.add(self.draw_.text('ϕ ='+str(np.round(inputs[2].tolist(),2)), insert=(x+58, y_up*30+24), font_size=6))
 
     def draw_any(self, order, wires, name, para_dict=None):
         """

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -112,7 +112,7 @@ class DrawCircuit():
             elif isinstance(op, Delay):
                 name_ = ''
                 order = depth[op.wires[0]]
-                inputs = [op.n_tau, op.theta, op.phi]
+                inputs = [op.ntau, op.theta, op.phi]
                 self.draw_sq(order, op.wires, inputs=inputs, name=name_, delay=True)
                 order_dic[order] = order_dic[order] + op.wires
                 for i in op.wires:

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -226,7 +226,7 @@ class DrawCircuit():
 
     def draw_sq(self, order, wires, r=None, theta=None, name=None):
         """
-        Draw squeezing gate, displacement gate, delay loop.
+        Draw squeezing gate, displacement gate.
         """
         x = 90 * order + 40
         y_up = wires[0]

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -78,7 +78,6 @@ class DoubleGate(Gate):
             wires = [0, 1]
         super().__init__(name=name, nmode=nmode, wires=wires, cutoff=cutoff, noise=noise, mu=mu, sigma=sigma)
         assert len(self.wires) == 2, f'{self.name} must act on two modes'
-        # assert self.wires[0] + 1 == self.wires[1], f'{self.name} must act on the adjacent modes'
         self.requires_grad = requires_grad
         self.init_para(inputs)
 
@@ -1491,40 +1490,42 @@ class DisplacementMomentum(Displacement):
         self.update_matrix()
         self.update_transform_xp()
 
+
 class Delay(SingleGate):
     r"""Delay loop.
+
     Args:
-        inputs (Any, optional): The parameters of the delay loop, inputs = [N, [bs_theta], [r_theta]].
-        N: modes in delay loop, bs_theta: periodic parameters for BS_theta gate, r_theta: periodic parameters for rotation
-        gate, Default: ``None``.
-        nmode (int, optional): The number of modes that the quantum operation acts on. Default: 1
+        inputs (Any, optional): The parameters of the gate. Default: ``None``
+        ntau (int, optional): The number of modes in the delay loop. Default: 1
+        nmode (int, optional): The number of spatial modes that the quantum operation acts on. Default: 1
         wires (int, List[int] or None, optional): The indices of the modes that the quantum operation acts on.
             Default: ``None``
         cutoff (int or None, optional): The Fock space truncation. Default: ``None``
         requires_grad (bool, optional): Whether the parameters are ``nn.Parameter`` or ``buffer``.
             Default: ``False`` (which means ``buffer``)
-        type(str): Delay loop with bs gate or mzi gate. Default: ``bs``,
+        convention (str, optional): The convention of the type of the delay loop, including ``'bs'`` and ``'mzi'``.
+            Default: ``'bs'``
         noise (bool, optional): Whether to introduce Gaussian noise. Default: ``False``
         mu (float, optional): The mean of Gaussian noise. Default: 0
         sigma (float, optional): The standard deviation of Gaussian noise. Default: 0.1
     """
     def __init__(
         self,
-        n_tau: int = 1,
         inputs: Any = None,
+        ntau: int = 1,
         nmode: int = 1,
         wires: Union[int, List[int], None] = None,
         cutoff: Optional[int] = None,
+        convention: str = 'bs',
         requires_grad: bool = False,
-        type: str = 'bs',
         noise: bool = False,
         mu: float = 0,
         sigma: float = 0.1
     ) -> None:
         super().__init__(name='Delay', inputs=inputs, nmode=nmode, wires=wires, cutoff=cutoff,
                          requires_grad=requires_grad, noise=noise, mu=mu, sigma=sigma)
-        self.n_tau = n_tau
-        self._type = type
+        self.ntau = ntau
+        self.convention = convention
         self.npara = 2
 
     def inputs_to_tensor(self, inputs: Any = None) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1561,5 +1562,6 @@ class Delay(SingleGate):
         else:
             self.register_buffer('theta', theta)
             self.register_buffer('phi', phi)
+
     def extra_repr(self) -> str:
-        return f'wires={self.wires}, n_tau = {self.n_tau}, theta={self.theta.item()}, phi={self.phi.item()}, type = {self._type}'
+        return f'wires={self.wires}, ntau={self.ntau}, theta={self.theta.item()}, phi={self.phi.item()}, convention={self.convention}'

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -16,6 +16,7 @@ from ..qmath import is_unitary
 
 class SingleGate(Gate):
     """Single-mode photonic quantum gate.
+
     Args:
         name (str or None, optional): The name of the gate. Default: ``None``
         inputs (Any, optional): The parameters of the gate. Default: ``None``
@@ -49,6 +50,7 @@ class SingleGate(Gate):
 
 class DoubleGate(Gate):
     """Two-mode photonic quantum gate.
+
     Args:
         name (str or None, optional): The name of the gate. Default: ``None``
         inputs (Any, optional): The parameters of the gate. Default: ``None``

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -1501,10 +1501,10 @@ class Delay(SingleGate):
         wires (int, List[int] or None, optional): The indices of the modes that the quantum operation acts on.
             Default: ``None``
         cutoff (int or None, optional): The Fock space truncation. Default: ``None``
-        requires_grad (bool, optional): Whether the parameters are ``nn.Parameter`` or ``buffer``.
-            Default: ``False`` (which means ``buffer``)
         convention (str, optional): The convention of the type of the delay loop, including ``'bs'`` and ``'mzi'``.
             Default: ``'bs'``
+        requires_grad (bool, optional): Whether the parameters are ``nn.Parameter`` or ``buffer``.
+            Default: ``False`` (which means ``buffer``)
         noise (bool, optional): Whether to introduce Gaussian noise. Default: ``False``
         mu (float, optional): The mean of Gaussian noise. Default: 0
         sigma (float, optional): The standard deviation of Gaussian noise. Default: 0.1

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -1521,6 +1521,7 @@ class Delay(SingleGate):
         super().__init__(name='Delay', inputs=inputs, nmode=nmode, wires=wires, cutoff=cutoff,
                          requires_grad=requires_grad, noise=noise, mu=mu, sigma=sigma)
         self.init_para(inputs)
+        self.npara = 2 * len(self.inputs[1])
 
     def inputs_to_tensor(self, inputs: Any = None) -> List[torch.Tensor]:
         """Convert inputs to torch.Tensor."""

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -1495,7 +1495,7 @@ class Delay(SingleGate):
     r"""Delay loop.
     Args:
         inputs (Any, optional): The parameters of the delay loop, inputs = [N, [bs_theta], [r_theta]].
-        N: modes in delay loop, bs_theta: periodic parameters for BS_phi gate, r_theta: periodic parameters for rotation
+        N: modes in delay loop, bs_theta: periodic parameters for BS_theta gate, r_theta: periodic parameters for rotation
         gate, Default: ``None``.
         nmode (int, optional): The number of modes that the quantum operation acts on. Default: 1
         wires (int, List[int] or None, optional): The indices of the modes that the quantum operation acts on.
@@ -1520,18 +1520,17 @@ class Delay(SingleGate):
     ) -> None:
         super().__init__(name='Delay', inputs=inputs, nmode=nmode, wires=wires, cutoff=cutoff,
                          requires_grad=requires_grad, noise=noise, mu=mu, sigma=sigma)
-        # self.npara = 3
         self.init_para(inputs)
 
-    def inputs_to_tensor(self, inputs: Any = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    def inputs_to_tensor(self, inputs: Any = None) -> List[torch.Tensor]:
         """Convert inputs to torch.Tensor."""
         if inputs is None:
             bs_theta = torch.rand(1)[0] * 2 * torch.pi
             r_theta = torch.rand(1)[0] * 2 * torch.pi
             inputs = [torch.tensor(1), bs_theta, r_theta]
         else:
-            assert len(inputs)==3, 'need 3 inputs for delay loop'
-            assert len(inputs[1])==len(inputs[2]), 'the inputs parametrers must match'
+            assert len(inputs) == 3, 'need 3 inputs for delay loop'
+            assert len(inputs[1]) == len(inputs[2]), 'the inputs parametrers must match'
             if not isinstance(inputs[0], torch.Tensor):
                 inputs[0] = torch.tensor(inputs[0], dtype=torch.int64)
             if not isinstance(inputs[1], torch.Tensor):
@@ -1546,4 +1545,4 @@ class Delay(SingleGate):
         self.inputs = inputs
 
     def extra_repr(self) -> str:
-        return f'wires={self.wires}, N ={self.inputs[0]}, bs_thetas={self.inputs[1]}, r_thetas={self.inputs[2]}'
+        return f'wires={self.wires}, N={self.inputs[0]}, bs_thetas={self.inputs[1]}, r_thetas={self.inputs[2]}'

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -91,7 +91,7 @@ class Homodyne(Generaldyne):
         wires (List[int] or None, optional): The indices of the modes that the quantum operation acts on.
             Default: ``None``
         cutoff (int or None, optional): The Fock space truncation. Default: ``None``
-        eps (float, optional): The measurement accuracy. Default: 2e-4
+        eps (float, optional): The measurement accuracy. Default: 1e-6
         requires_grad (bool, optional): Whether the parameter is ``nn.Parameter`` or ``buffer``.
             Default: ``False`` (which means ``buffer``)
         name (str, optional): The name of the gate. Default: ``'Homodyne'``
@@ -105,7 +105,7 @@ class Homodyne(Generaldyne):
         nmode: int = 1,
         wires: Union[int, List[int], None] = None,
         cutoff: Optional[int] = None,
-        eps: float = 2e-4,
+        eps: float = 1e-6,
         requires_grad: bool = False,
         noise: bool = False,
         mu: float = 0,

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -115,7 +115,7 @@ class Gate(Operation):
         """Get the global unitary matrix acting on creation operators."""
         matrix = self.update_matrix()
         assert matrix.shape[-2] == matrix.shape[-1] == len(self.wires), 'The matrix may not act on creation operators.'
-        u = matrix.new_zeros(self.nmode, self.nmode, dtype=matrix.dtype, device=matrix.device)
+        u = matrix.new_zeros(self.nmode, self.nmode)
         u[torch.arange(self.nmode), torch.arange(self.nmode)] = 1
         u[np.ix_(self.wires, self.wires)] = matrix
         return u
@@ -151,17 +151,17 @@ class Gate(Operation):
         """Get the global symplectic matrix acting on quadrature operators in xxpp order."""
         matrix, _ = self.update_transform_xp()
         assert matrix.shape[-2] == matrix.shape[-1] == 2 * len(self.wires), 'The matrix may not act on xxpp operators.'
-        s = matrix.new_zeros(2 * self.nmode, 2 * self.nmode, dtype=matrix.dtype, device=matrix.device)
+        s = matrix.new_zeros(2 * self.nmode, 2 * self.nmode)
         s[torch.arange(2 * self.nmode), torch.arange(2 * self.nmode)] = 1
         wires = self.wires + [wire + self.nmode for wire in self.wires]
-        s[np.ix_(wires, wires)] = matrix # need support vmap
+        s[np.ix_(wires, wires)] = matrix
         return s
 
     def get_displacement(self) -> torch.Tensor:
         """Get the global displacement vector acting on quadrature operators in xxpp order."""
         _, vector = self.update_transform_xp()
         assert vector.shape[-2] == 2 * len(self.wires), 'The vector may not act on xxpp operators.'
-        d = vector.new_zeros(2 * self.nmode, 1, dtype=vector.dtype, device=vector.device)
+        d = vector.new_zeros(2 * self.nmode, 1)
         wires = self.wires + [wire + self.nmode for wire in self.wires]
         d[np.ix_(wires)] = vector
         return d

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -115,7 +115,8 @@ class Gate(Operation):
         """Get the global unitary matrix acting on creation operators."""
         matrix = self.update_matrix()
         assert matrix.shape[-2] == matrix.shape[-1] == len(self.wires), 'The matrix may not act on creation operators.'
-        u = torch.eye(self.nmode, dtype=matrix.dtype, device=matrix.device)
+        u = matrix.new_zeros(self.nmode, self.nmode, dtype=matrix.dtype, device=matrix.device)
+        u[torch.arange(self.nmode), torch.arange(self.nmode)] = 1
         u[np.ix_(self.wires, self.wires)] = matrix
         return u
 
@@ -150,16 +151,17 @@ class Gate(Operation):
         """Get the global symplectic matrix acting on quadrature operators in xxpp order."""
         matrix, _ = self.update_transform_xp()
         assert matrix.shape[-2] == matrix.shape[-1] == 2 * len(self.wires), 'The matrix may not act on xxpp operators.'
-        s = torch.eye(2 * self.nmode, dtype=matrix.dtype, device=matrix.device)
+        s = matrix.new_zeros(2 * self.nmode, 2 * self.nmode, dtype=matrix.dtype, device=matrix.device)
+        s[torch.arange(2 * self.nmode), torch.arange(2 * self.nmode)] = 1
         wires = self.wires + [wire + self.nmode for wire in self.wires]
-        s[np.ix_(wires, wires)] = matrix
+        s[np.ix_(wires, wires)] = matrix # need support vmap
         return s
 
     def get_displacement(self) -> torch.Tensor:
         """Get the global displacement vector acting on quadrature operators in xxpp order."""
         _, vector = self.update_transform_xp()
         assert vector.shape[-2] == 2 * len(self.wires), 'The vector may not act on xxpp operators.'
-        d = torch.zeros(2 * self.nmode, 1, dtype=vector.dtype, device=vector.device)
+        d = vector.new_zeros(2 * self.nmode, 1, dtype=vector.dtype, device=vector.device)
         wires = self.wires + [wire + self.nmode for wire in self.wires]
         d[np.ix_(wires)] = vector
         return d

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -120,7 +120,6 @@ class Gate(Operation):
         nmode2 = self.nmode - nmode1 - len(self.wires)
         m1 = torch.eye(nmode1, dtype=matrix.dtype, device=matrix.device)
         m2 = torch.eye(nmode2, dtype=matrix.dtype, device=matrix.device)
-        # return torch.block_diag(m1, matrix, m2)
         u_global = torch.block_diag(m1, matrix, m2)
         if len(self.wires) == 2:
             indices_1 = [self.wires[0]+1]
@@ -165,10 +164,9 @@ class Gate(Operation):
         nmode2 = self.nmode - nmode1 - len(self.wires)
         m1 = torch.eye(2 * nmode1, dtype=matrix.dtype, device=matrix.device)
         m2 = torch.eye(2 * nmode2, dtype=matrix.dtype, device=matrix.device)
-        # return xpxp_to_xxpp(torch.block_diag(m1, matrix_xpxp, m2)) # here change order to xxpp
         sp_global = torch.block_diag(m1, matrix_xpxp, m2) # xpxp
         if len(self.wires) == 2:
-            indices_1 = [2*(self.wires[0]+1), 2*(self.wires[0]+1)+1 ]
+            indices_1 = [2*(self.wires[0]+1), 2*(self.wires[0]+1)+1]
             indices_2 = [2*self.wires[1], 2*self.wires[1]+1]
             permute_m = permute_mat(sp_global, indices_1, indices_2)
             sp_global = permute_m @ sp_global @ permute_m

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -125,7 +125,7 @@ class Gate(Operation):
             indices_1 = [self.wires[0]+1]
             indices_2 = [self.wires[1]]
             permute_m = permute_mat(u_global, indices_1, indices_2) # consider non-adjacent wires
-            u_global = permute_m @ u_global @ permute_m
+            u_global = permute_m @ u_global @ permute_m # permute_m = permute_m^{-1}
         return u_global
 
     def get_matrix_state(self, matrix: torch.Tensor) -> torch.Tensor:
@@ -169,7 +169,7 @@ class Gate(Operation):
             indices_1 = [2*(self.wires[0]+1), 2*(self.wires[0]+1)+1]
             indices_2 = [2*self.wires[1], 2*self.wires[1]+1]
             permute_m = permute_mat(sp_global, indices_1, indices_2)
-            sp_global = permute_m @ sp_global @ permute_m
+            sp_global = permute_m @ sp_global @ permute_m # permute_m = permute_m^{-1}
         return xpxp_to_xxpp(sp_global) # here change order to xxpp
 
 

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -172,7 +172,7 @@ def fock_combinations(nmode: int, nphoton: int) -> List:
     return result
 
 
-def shift_fun(a: List, step: int) -> List:
+def shift_func(a: List, step: int) -> List:
     """Shift the elements of a list by the given step."""
     if len(a) <= 1:
         return a

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -8,7 +8,6 @@ import warnings
 from collections import defaultdict
 from typing import Callable, Dict, List, Tuple
 
-from math import gcd
 import numpy as np
 import torch
 from torch import vmap
@@ -171,6 +170,14 @@ def fock_combinations(nmode: int, nphoton: int) -> List:
 
     backtrack([], nmode, nphoton)
     return result
+
+
+def shift_fun(a: List, step: int) -> List:
+    """Shift the elements of a list by the given step."""
+    if len(a) <= 1:
+        return a
+    step = step % len(a)
+    return a[-step:] + a[:-step]
 
 
 def xxpp_to_xpxp(matrix: torch.Tensor) -> torch.Tensor:
@@ -340,10 +347,3 @@ def sample_sc_mcmc(prob_func: Callable,
         for key, value in dict_sample.items():
             merged_samples[key] += value
     return merged_samples
-
-def shift_fun(a, step):
-    """Shift the elements of a list by given step."""
-    if len(a) <= 1:
-        return a
-    step = step % len(a)
-    return a[-step:] + a[:-step]

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -8,6 +8,7 @@ import warnings
 from collections import defaultdict
 from typing import Callable, Dict, List, Tuple
 
+from math import gcd
 import numpy as np
 import torch
 from torch import vmap
@@ -340,24 +341,10 @@ def sample_sc_mcmc(prob_func: Callable,
             merged_samples[key] += value
     return merged_samples
 
-def permute_mat(mat, indices_1, indices_2):
-    """
-    Reorder the matrix by exchanging the column and row i, j from indices_1, indices_2.
-    """
-    def permute_single(i, j, size):
-        """
-        Return the permute matrix for exchanging i-th row with j-th row of matrix a
-        """
-        p_row = torch.eye(size)
-        p_row[[i, j]] = p_row[[j, i]]
-        return p_row
-
-    n = mat.size()[-1]
-    exchange_mat = torch.eye(n, dtype=mat.dtype)
-    for k in range(len(indices_1)-1, -1, -1):
-        i = indices_1[k]
-        j = indices_2[k]
-        p_mat = permute_single(i, j, n)
-        p_mat = p_mat.to(mat.dtype)
-        exchange_mat = p_mat @ exchange_mat
-    return exchange_mat
+def lcm(a, b):
+    return abs(a*b) // gcd(a,b)
+def lcm_multiple(numbers):
+    result = numbers[0]
+    for num in numbers[1:]:
+        result = lcm(result, num)
+    return result

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -341,10 +341,9 @@ def sample_sc_mcmc(prob_func: Callable,
             merged_samples[key] += value
     return merged_samples
 
-def lcm(a, b):
-    return abs(a*b) // gcd(a,b)
-def lcm_multiple(numbers):
-    result = numbers[0]
-    for num in numbers[1:]:
-        result = lcm(result, num)
-    return result
+def shift_fun(a, step):
+    """Shift the elements of a list by given step."""
+    if len(a) <= 1:
+        return a
+    step = step % len(a)
+    return a[-step:] + a[:-step]

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -172,12 +172,15 @@ def fock_combinations(nmode: int, nphoton: int) -> List:
     return result
 
 
-def shift_func(a: List, step: int) -> List:
-    """Shift the elements of a list by the given step."""
-    if len(a) <= 1:
-        return a
-    step = step % len(a)
-    return a[-step:] + a[:-step]
+def shift_func(l: List, nstep: int) -> List:
+    """Shift a list by a number of steps.
+
+    If ``nstep`` is positive, it shifts to the left.
+    """
+    if len(l) <= 1:
+        return l
+    nstep = nstep % len(l)
+    return l[nstep:] + l[:nstep]
 
 
 def xxpp_to_xpxp(matrix: torch.Tensor) -> torch.Tensor:

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -339,3 +339,25 @@ def sample_sc_mcmc(prob_func: Callable,
         for key, value in dict_sample.items():
             merged_samples[key] += value
     return merged_samples
+
+def permute_mat(mat, indices_1, indices_2):
+    """
+    Reorder the matrix by exchanging the column and row i, j from indices_1, indices_2.
+    """
+    def permute_single(i, j, size):
+        """
+        Return the permute matrix for exchanging i-th row with j-th row of matrix a
+        """
+        p_row = torch.eye(size)
+        p_row[[i, j]] = p_row[[j, i]]
+        return p_row
+
+    n = mat.size()[-1]
+    exchange_mat = torch.eye(n, dtype=mat.dtype)
+    for k in range(len(indices_1)-1, -1, -1):
+        i = indices_1[k]
+        j = indices_2[k]
+        p_mat = permute_single(i, j, n)
+        p_mat = p_mat.to(mat.dtype)
+        exchange_mat = p_mat @ exchange_mat
+    return exchange_mat

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -338,3 +338,25 @@ def sample_sc_mcmc(prob_func: Callable,
         for key, value in dict_sample.items():
             merged_samples[key] += value
     return merged_samples
+
+def permute_mat(mat, indices_1, indices_2):
+    """
+    Reorder the matrix by exchanging the column and row i, j from indices_1, indices_2.
+    """
+    def permute_single(i, j, size):
+        """
+        Return the permute matrix for exchanging i-th row with j-th row of matrix a
+        """
+        p_row = torch.eye(size)
+        p_row[[i, j]] = p_row[[j, i]]
+        return p_row
+
+    n = mat.size()[-1]
+    exchange_mat = torch.eye(n, dtype=mat.dtype)
+    for k in range(len(indices_1)-1, -1, -1):
+        i = indices_1[k]
+        j = indices_2[k]
+        p_mat = permute_single(i, j, n)
+        p_mat = p_mat.to(mat.dtype)
+        exchange_mat = p_mat @ exchange_mat
+    return exchange_mat

--- a/tests/test_with_xanadu.py
+++ b/tests/test_with_xanadu.py
@@ -195,6 +195,6 @@ def test_non_adjacent_bs_gaussian():
     cir.bs([0,2], [angles[8], angles[9]])
     cir.bs([1,3], [angles[10], angles[11]])
 
-    state = circ()
+    state = cir()
     err = abs(state[0].squeeze() - cov_sf).sum() + abs(state[1].squeeze() - mean_sf).sum()
     assert err < 1e-5

--- a/tests/test_with_xanadu.py
+++ b/tests/test_with_xanadu.py
@@ -131,40 +131,41 @@ def test_measure_homodyne():
 
 
 def test_non_adjacent_bs_fock():
-    n=3
+    n = 3
     angles = np.random.rand(6)
-    prog0 = sf.Program(n)
-    with prog0.context as q:
+    prog = sf.Program(n)
+    with prog.context as q:
         Fock(1) | q[0]
-        Fock(1)  | q[1]
-        Fock(1)  | q[2]
+        Fock(1) | q[1]
+        Fock(1) | q[2]
         Rgate(angles[0]) | q[0]
         Rgate(angles[1]) | q[1]
         BSgate(angles[2], angles[3]) | (q[0], q[2])
         BSgate(angles[4], angles[5]) | (q[1], q[2])
-    eng0 = sf.Engine("fock", backend_options={'cutoff_dim':4})
-    result0 = eng0.run(prog0)
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': 4})
+    result = eng.run(prog)
 
     nmode = n
-    circ = dq.QumodeCircuit(nmode=nmode, init_state=[1,1,1], cutoff=3, backend='fock', basis=True)
-    circ.ps([0], angles[0])
-    circ.ps([1], angles[1])
-    circ.bs([0,2], [angles[2], angles[3]])
-    circ.bs([1,2], [angles[4], angles[5]])
-    st = circ(is_prob=True)
+    cir = dq.QumodeCircuit(nmode=nmode, init_state=[1,1,1], cutoff=3, backend='fock', basis=True)
+    cir.ps(0, angles[0])
+    cir.ps(1, angles[1])
+    cir.bs([0,2], [angles[2], angles[3]])
+    cir.bs([1,2], [angles[4], angles[5]])
+    state = cir(is_prob=True)
     err = 0
-    for key in st.keys():
-        dq_prob = st[key]
+    for key in state.keys():
+        dq_prob = state[key]
         fock_st = key.state.tolist()
-        sf_prob = result0.state.fock_prob(fock_st)
-        err = err + abs(dq_prob-sf_prob)
+        sf_prob = result.state.fock_prob(fock_st)
+        err = err + abs(dq_prob - sf_prob)
     assert err < 1e-6
 
+
 def test_non_adjacent_bs_gaussian():
-    n=4
+    n = 4
     angles = np.random.rand(12)
-    prog0 = sf.Program(n)
-    with prog0.context as q:
+    prog = sf.Program(n)
+    with prog.context as q:
         Sgate(angles[0]) | q[0]
         Sgate(angles[1]) | q[1]
         Sgate(angles[2]) | q[2]
@@ -175,25 +176,25 @@ def test_non_adjacent_bs_gaussian():
         Dgate(angles[7]) | q[3]
         BSgate(angles[8], angles[9]) | (q[0], q[2])
         BSgate(angles[10], angles[11]) | (q[1], q[3])
-    eng0 = sf.Engine("gaussian")
-    result0 = eng0.run(prog0)
-    cov_sf = result0.state.cov()
-    mean_sf = result0.state.means()
+    eng = sf.Engine('gaussian')
+    result = eng.run(prog)
+    cov_sf = result.state.cov()
+    mean_sf = result.state.means()
 
     nmode = n
-    circ = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=3, backend='gaussian', basis=True)
-    circ.s([0], r=angles[0])
-    circ.s([1], r=angles[1])
-    circ.s([2], r=angles[2])
-    circ.s([3], r=angles[3])
-    circ.d([0], r=angles[4])
-    circ.d([1], r=angles[5])
-    circ.d([2], r=angles[6])
-    circ.d([3], r=angles[7])
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=3, backend='gaussian')
+    cir.s(0, r=angles[0])
+    cir.s(1, r=angles[1])
+    cir.s(2, r=angles[2])
+    cir.s(3, r=angles[3])
+    cir.d(0, r=angles[4])
+    cir.d(1, r=angles[5])
+    cir.d(2, r=angles[6])
+    cir.d(3, r=angles[7])
 
-    circ.bs([0,2], [angles[8], angles[9]])
-    circ.bs([1,3], [angles[10], angles[11]])
+    cir.bs([0,2], [angles[8], angles[9]])
+    cir.bs([1,3], [angles[10], angles[11]])
 
-    st = circ()
-    err = abs(st[0].squeeze()-cov_sf).sum() + abs(st[1].squeeze()-mean_sf).sum()
+    state = circ()
+    err = abs(state[0].squeeze() - cov_sf).sum() + abs(state[1].squeeze() - mean_sf).sum()
     assert err < 1e-5

--- a/tests/test_with_xanadu.py
+++ b/tests/test_with_xanadu.py
@@ -5,7 +5,7 @@ import strawberryfields as sf
 import thewalrus
 import torch
 from deepquantum.photonic import quadrature_to_ladder, hafnian, torontonian
-from strawberryfields.ops import Sgate, BSgate, Rgate, MeasureHomodyne, Dgate
+from strawberryfields.ops import Sgate, BSgate, Rgate, MeasureHomodyne, Dgate, Fock
 
 
 def test_hafnian():
@@ -128,3 +128,72 @@ def test_measure_homodyne():
     state = cir.state_measured
     err = abs(state[0] - result.state.cov()).max() # compare the covariance matrix after the measurement
     assert err < 1e-6
+
+
+def test_non_adjacent_bs_fock():
+    n=3
+    angles = np.random.rand(6)
+    prog0 = sf.Program(n)
+    with prog0.context as q:
+        Fock(1) | q[0]
+        Fock(1)  | q[1]
+        Fock(1)  | q[2]
+        Rgate(angles[0]) | q[0]
+        Rgate(angles[1]) | q[1]
+        BSgate(angles[2], angles[3]) | (q[0], q[2])
+        BSgate(angles[4], angles[5]) | (q[1], q[2])
+    eng0 = sf.Engine("fock", backend_options={'cutoff_dim':4})
+    result0 = eng0.run(prog0)
+
+    nmode = n
+    circ = dq.QumodeCircuit(nmode=nmode, init_state=[1,1,1], cutoff=3, backend='fock', basis=True)
+    circ.ps([0], angles[0])
+    circ.ps([1], angles[1])
+    circ.bs([0,2], [angles[2], angles[3]])
+    circ.bs([1,2], [angles[4], angles[5]])
+    st = circ(is_prob=True)
+    err = 0
+    for key in st.keys():
+        dq_prob = st[key]
+        fock_st = key.state.tolist()
+        sf_prob = result0.state.fock_prob(fock_st)
+        err = err + abs(dq_prob-sf_prob)
+    assert err < 1e-6
+
+def test_non_adjacent_bs_gaussian():
+    n=4
+    angles = np.random.rand(12)
+    prog0 = sf.Program(n)
+    with prog0.context as q:
+        Sgate(angles[0]) | q[0]
+        Sgate(angles[1]) | q[1]
+        Sgate(angles[2]) | q[2]
+        Sgate(angles[3]) | q[3]
+        Dgate(angles[4]) | q[0]
+        Dgate(angles[5]) | q[1]
+        Dgate(angles[6]) | q[2]
+        Dgate(angles[7]) | q[3]
+        BSgate(angles[8], angles[9]) | (q[0], q[2])
+        BSgate(angles[10], angles[11]) | (q[1], q[3])
+    eng0 = sf.Engine("gaussian")
+    result0 = eng0.run(prog0)
+    cov_sf = result0.state.cov()
+    mean_sf = result0.state.means()
+
+    nmode = n
+    circ = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=3, backend='gaussian', basis=True)
+    circ.s([0], r=angles[0])
+    circ.s([1], r=angles[1])
+    circ.s([2], r=angles[2])
+    circ.s([3], r=angles[3])
+    circ.d([0], r=angles[4])
+    circ.d([1], r=angles[5])
+    circ.d([2], r=angles[6])
+    circ.d([3], r=angles[7])
+
+    circ.bs([0,2], [angles[8], angles[9]])
+    circ.bs([1,3], [angles[10], angles[11]])
+
+    st = circ()
+    err = abs(st[0].squeeze()-cov_sf).sum() + abs(st[1].squeeze()-mean_sf).sum()
+    assert err < 1e-5


### PR DESCRIPTION
# Update details
## 1. Support non-adjacent BS gate
![image](https://github.com/user-attachments/assets/143c779f-a8d7-4677-bb86-e1cde5c49f5b)

## 2. Support adding delay loop in Gaussian backend using `circ.delay`  in  `QumodeCircuit` and  `QumodeCircuitTDM` module.
### 2.1 Support multiple delay loops acting on the corresponding wires
![image](https://github.com/user-attachments/assets/0189999d-0864-4d99-afa5-bb62b21a6d6c)

Using `circ.draw(unroll=True)` to check the equivalent circuit after forward. 
![image](https://github.com/user-attachments/assets/e4a3454c-61ea-4345-936b-f550289cb065)

## 3. Able to generate cluster state using delay loop, such as EPR, GHZ state,  by using data encoding.
![image](https://github.com/user-attachments/assets/23018b48-2b3c-41dc-84ad-90657e2e9e96)

![image](https://github.com/user-attachments/assets/b94ac11b-c789-4adc-950b-14cd30ced3a5)

