### PR TITLE
Fix a bug with output dtype in Fock backend and support sorting FockState lexicographically

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -587,7 +587,7 @@ class QumodeCircuit(Operation):
             amp = torch.zeros(state.shape[0], dtype=unitary.dtype, device=unitary.device)
             if idx_nonzero.numel() != 0:
                 sub_mats = vmap(sub_matrix, in_dims=(None, 0, None))(unitary, state[idx_nonzero], final_state)
-                per_norms = self._get_permanent_norms(state[idx_nonzero], final_state)
+                per_norms = self._get_permanent_norms(state[idx_nonzero], final_state).to(unitary.dtype)
                 rst = vmap(self._get_amplitude_fock_vmap)(sub_mats, per_norms).flatten()
                 amp[idx_nonzero] = rst
         return amp
@@ -595,7 +595,7 @@ class QumodeCircuit(Operation):
     def _get_amplitude_fock_vmap(self, sub_mat: torch.Tensor, per_norm: torch.Tensor) -> torch.Tensor:
         """Get the transfer amplitude."""
         per = permanent(sub_mat)
-        amp = per / per_norm.to(per.dtype)
+        amp = per / per_norm
         return amp.reshape(-1)
 
     def get_prob(
@@ -879,7 +879,7 @@ class QumodeCircuit(Operation):
         """
         final_states = self._all_fock_basis
         sub_mats = vmap(sub_matrix, in_dims=(None, None, 0))(unitary, init_state, final_states)
-        per_norms = self._get_permanent_norms(init_state, final_states)
+        per_norms = self._get_permanent_norms(init_state, final_states).to(unitary.dtype)
         rst = vmap(self._get_prob_fock_vmap)(sub_mats, per_norms)
         state_dict = {}
         prob_dict = defaultdict(list)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -295,7 +295,7 @@ class QumodeCircuit(Operation):
             if self._state_expand is not None:
                 unitary = torch.block_diag(unitary, torch.eye(1, dtype=unitary.dtype, device=unitary.device))
             sub_mats = vmap(sub_matrix, in_dims=(None, None, 0))(unitary, state, final_states)
-            per_norms = self._get_permanent_norms(state, final_states)
+            per_norms = self._get_permanent_norms(state, final_states).to(unitary.dtype)
             if is_prob:
                 rst = vmap(self._get_prob_fock_vmap)(sub_mats, per_norms)
             else:
@@ -581,7 +581,7 @@ class QumodeCircuit(Operation):
         if state.ndim == 1:
             sub_mat = sub_matrix(unitary, state, final_state)
             per = permanent(sub_mat)
-            amp = per / self._get_permanent_norms(state, final_state)
+            amp = per / self._get_permanent_norms(state, final_state).to(per.dtype)
         else:
             idx_nonzero = torch.where(torch.sum(state, dim=-1) == torch.sum(final_state))[0]
             amp = torch.zeros(state.shape[0], dtype=unitary.dtype, device=unitary.device)
@@ -595,7 +595,7 @@ class QumodeCircuit(Operation):
     def _get_amplitude_fock_vmap(self, sub_mat: torch.Tensor, per_norm: torch.Tensor) -> torch.Tensor:
         """Get the transfer amplitude."""
         per = permanent(sub_mat)
-        amp = per / per_norm
+        amp = per / per_norm.to(per.dtype)
         return amp.reshape(-1)
 
     def get_prob(

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -132,7 +132,7 @@ def permanent_ryser(mat: torch.Tensor) -> torch.Tensor:
 
 def product_factorial(state: torch.Tensor) -> torch.Tensor:
     """Get the product of the factorial from the Fock state, i.e., :math:`|s_1,s_2,...s_n> --> s_1!*s_2!*...s_n!`."""
-    return torch.exp(torch.lgamma(state.double() + 1).sum(-1, keepdim=True)).float() # nature log gamma function
+    return torch.exp(torch.lgamma(state.double() + 1).sum(-1, keepdim=True)) # nature log gamma function
 
 
 def fock_combinations(nmode: int, nphoton: int) -> List:

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -131,7 +131,7 @@ class FockState(nn.Module):
                 temp += f'{key}: {value}\n'
             return hash(temp)
 
-    def __lt__(self, other: 'FockState')  -> bool:
+    def __lt__(self, other: 'FockState') -> bool:
         tuple_self = tuple(self.state.tolist())
         tuple_other = tuple(other.state.tolist())
         return tuple_self < tuple_other

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -131,6 +131,11 @@ class FockState(nn.Module):
                 temp += f'{key}: {value}\n'
             return hash(temp)
 
+    def __lt__(self, other: 'FockState')  -> bool:
+        tuple_self = tuple(self.state.tolist())
+        tuple_other = tuple(other.state.tolist())
+        return tuple_self < tuple_other
+
 
 class GaussianState(nn.Module):
     r"""A Gaussian state of n modes, representing by covariance matrix and displacement vector.


### PR DESCRIPTION
- [**output dtype in `fock` backend**] 

  ### Problem Description
  Always get `float` dtype in output dictionary values, in `fock` backend
  
  ### Investigation
  `permanent` turns to be a scalar, so `permanent/per_norm` will not adjust to a more precise dtype automatically. 
  
  ### Method
  manually set `per_norm.dtype` in certain circumstances.

- [**sorting `FockState` lexicographically**] 
 Support comparing `FockState` so that the output dictionary can be sorted by keys lexicographically