### PR TITLE
Add arg: cutoff into fock_combinations for better performance

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -653,10 +653,8 @@ class QumodeCircuit(Operation):
         """Get all possible fock basis states according to the initial state."""
         nphoton = torch.max(torch.sum(init_state, dim=-1))
         nmode = len(init_state)
-        states = torch.tensor(fock_combinations(nmode, nphoton), dtype=torch.long, device=init_state.device)
-        max_values, _ = torch.max(states, dim=1)
-        mask = max_values < self.cutoff
-        return torch.masked_select(states, mask.unsqueeze(1)).view(-1, states.shape[-1])
+        states = torch.tensor(fock_combinations(nmode, nphoton, self.cutoff), dtype=torch.long, device=init_state.device)
+        return states
 
     def _get_odd_even_fock_basis(self, detector: Optional[str] = None) -> Union[Tuple[List], List]:
         """Split the fock basis into the odd and even photon number parts."""

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -135,7 +135,7 @@ def product_factorial(state: torch.Tensor) -> torch.Tensor:
     return torch.exp(torch.lgamma(state.double() + 1).sum(-1, keepdim=True)) # nature log gamma function
 
 
-def fock_combinations(nmode: int, nphoton: int) -> List:
+def fock_combinations(nmode: int, nphoton: int, cutoff: int) -> List:
     """Generate all possible combinations of Fock states for a given number of modes and photons.
 
     Args:
@@ -165,7 +165,7 @@ def fock_combinations(nmode: int, nphoton: int) -> List:
             if num_sum == 0:
                 result.append(state)
             return
-        for i in range(num_sum + 1):
+        for i in range(min((num_sum + 1), cutoff)):
             backtrack(state + [i], length - 1, num_sum - i)
 
     backtrack([], nmode, nphoton)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -148,9 +148,9 @@ def fock_combinations(nmode: int, nphoton: int, cutoff: Optional[int] = None) ->
         occupation numbers for each mode.
 
     Examples:
-        >>> fock_combinations(2, 3, 4)
+        >>> fock_combinations(2, 3)
         [[0, 3], [1, 2], [2, 1], [3, 0]]
-        >>> fock_combinations(3, 2, 4)
+        >>> fock_combinations(3, 2)
         [[0, 0, 2], [0, 1, 1], [0, 2, 0], [1, 0, 1], [1, 1, 0], [2, 0, 0]]
         >>> fock_combinations(4, 4, 2)
         [[1, 1, 1, 1]]

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -136,21 +136,24 @@ def product_factorial(state: torch.Tensor) -> torch.Tensor:
 
 
 def fock_combinations(nmode: int, nphoton: int, cutoff: int) -> List:
-    """Generate all possible combinations of Fock states for a given number of modes and photons.
+    """Generate all possible combinations of Fock states for a given number of modes, photons, and cutoff.
 
     Args:
         nmode (int): The number of modes in the system.
         nphoton (int): The total number of photons in the system.
+        cutoff (int): The truncation number of photons in each mode.
 
     Returns:
         List[List[int]]: A list of all possible Fock states, each represented by a list of
         occupation numbers for each mode.
 
     Examples:
-        >>> fock_combinations(2, 3)
+        >>> fock_combinations(2, 3, 4)
         [[0, 3], [1, 2], [2, 1], [3, 0]]
-        >>> fock_combinations(3, 2)
+        >>> fock_combinations(3, 2, 4)
         [[0, 0, 2], [0, 1, 1], [0, 2, 0], [1, 0, 1], [1, 1, 0], [2, 0, 0]]
+        >>> fock_combinations(4, 4, 2)
+        [[1, 1, 1, 1]]
     """
     result = []
     def backtrack(state: List[int], length: int, num_sum: int) -> None:

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -6,7 +6,7 @@ import copy
 import itertools
 import warnings
 from collections import defaultdict
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -135,13 +135,13 @@ def product_factorial(state: torch.Tensor) -> torch.Tensor:
     return torch.exp(torch.lgamma(state.double() + 1).sum(-1, keepdim=True)) # nature log gamma function
 
 
-def fock_combinations(nmode: int, nphoton: int, cutoff: int) -> List:
+def fock_combinations(nmode: int, nphoton: int, cutoff: Optional[int] = None) -> List:
     """Generate all possible combinations of Fock states for a given number of modes, photons, and cutoff.
 
     Args:
         nmode (int): The number of modes in the system.
         nphoton (int): The total number of photons in the system.
-        cutoff (int): The truncation number of photons in each mode.
+        cutoff (int or None, optional): The Fock space truncation. Default: ``None``
 
     Returns:
         List[List[int]]: A list of all possible Fock states, each represented by a list of
@@ -155,6 +155,8 @@ def fock_combinations(nmode: int, nphoton: int, cutoff: int) -> List:
         >>> fock_combinations(4, 4, 2)
         [[1, 1, 1, 1]]
     """
+    if cutoff is None:
+        cutoff = nphoton + 1
     result = []
     def backtrack(state: List[int], length: int, num_sum: int) -> None:
         """A helper function that uses backtracking to generate all possible Fock states.


### PR DESCRIPTION
`fock_combinations` has large memory usage and low efficiency when nmode and nphoton are large. This PR is trying to enhance its performance when a small _cutoff_ is indicated.

![image](https://github.com/user-attachments/assets/0690a2ca-40db-4100-9824-af1f49e15215)
