### PR TITLE
Fix 'global_circuit' for MPS and add 'set_init_state' for the circuit

### DIFF
--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -382,6 +382,7 @@ class Gate(Operation):
             end2 = left
         wires = list(range(left, right + 1))
         out = MatrixProductState(nsite=mps.nsite, state=mps.tensors, chi=mps.chi, normalize=mps.normalize)
+        out.center = mps.center
         out.center_orthogonalization(end1, dc=-1, normalize=out.normalize)
         out.apply_mpo(mpo_tensors, wires)
         out.center_orthogonalization(end2, dc=-1, normalize=out.normalize)

--- a/src/deepquantum/photonic/tdm.py
+++ b/src/deepquantum/photonic/tdm.py
@@ -12,8 +12,9 @@ from .circuit import QumodeCircuit
 class QumodeCircuitTDM(QumodeCircuit):
     r"""Time-domain-multiplexed photonic quantum circuit.
 
-    Note: When using large squeezing parameters, we recommend using a double data type and
-        a smaller ``eps`` for Homodyne to avoid issues with non-positive definiteness of the covariance matrix.
+    Note:
+        When using large squeezing parameters, we recommend using a double data type and a smaller ``eps`` for Homodyne
+        to avoid issues with non-positive definiteness of the covariance matrix.
 
     Args:
         nmode (int): The number of spatial modes in the circuit.


### PR DESCRIPTION
## Example

```python
cir = dq.QumodeCircuit(2, [1,1], cutoff=4, basis=False, mps=True, chi=16)
cir.bs([0,1])
cir.delay(0, ntau=2)
cir.delay(1, ntau=2)
cir.draw()

cir_global = cir.global_circuit(2, use_deepcopy=True)
print(cir_global.get_unitary())
cir_global.draw()

cir_global.set_init_state([0,0,2,0,0,2,0,0])
cir_global()
```