### PR TITLE
Update github-release

### DIFF
--- a/.github/workflows/publish-to-pypi-github-release.yml
+++ b/.github/workflows/publish-to-pypi-github-release.yml
@@ -84,7 +84,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
- From `sigstore/gh-action-sigstore-python@v2.1.1` to `sigstore/gh-action-sigstore-python@v3.0.0`