### PR TITLE
Optimize 'fock_combinations'

### DIFF
--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -173,7 +173,7 @@ def fock_combinations(nmode: int, nphoton: int, cutoff: Optional[int] = None, na
         # Determine the effective length for cutoff
         effective_length = length - nancilla
         # skip iterations if remaining photons exceed the remaining cutoff
-        if nancilla == 0 and num_sum > cutoff * effective_length:
+        if nancilla == 0 and num_sum > (cutoff - 1) * effective_length:
             return
         for i in range(min((num_sum + 1), cutoff) if effective_length > 0 else (num_sum + 1)):
             backtrack(state + [i], length - 1, num_sum - i)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -172,6 +172,9 @@ def fock_combinations(nmode: int, nphoton: int, cutoff: Optional[int] = None, na
             return
         # Determine the effective length for cutoff
         effective_length = length - nancilla
+        # skip iterations if remaining photons exceed the remaining cutoff
+        if nancilla == 0 and num_sum > cutoff * effective_length:
+            return
         for i in range(min((num_sum + 1), cutoff) if effective_length > 0 else (num_sum + 1)):
             backtrack(state + [i], length - 1, num_sum - i)
 


### PR DESCRIPTION
- Optimize 'fock_combinations' for better performance when `nphoton` is large but `cutoff` is small
![image](https://github.com/user-attachments/assets/40bdb723-69cc-4fff-94bf-fba7bfe29afd)
