### PR TITLE
Support shots for expectation value

### DIFF
--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -337,7 +337,8 @@ class QubitCircuit(Operation):
                         cir_basis.h(wire)
                 cir_basis.to(dtype).to(device)
                 state = cir_basis(state=self.state)
-                samples = measure(state=state, shots=shots, wires=observable.wires, den_mat=self.den_mat)
+                wires = sum(observable.wires, [])
+                samples = measure(state=state, shots=shots, wires=wires, den_mat=self.den_mat)
                 if isinstance(samples, list):
                     expval = []
                     for sample in samples:
@@ -346,6 +347,8 @@ class QubitCircuit(Operation):
                     expval = torch.cat(expval)
                 elif isinstance(samples, dict):
                     expval = sample2expval(sample=samples).to(dtype).to(device)
+                    if self.state.ndim == 2:
+                        expval = expval.squeeze(0)
                 out.append(expval)
         out = torch.stack(out, dim=-1)
         return out

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -64,7 +64,7 @@ class QubitCircuit(Operation):
         self.state = None
         self.ndata = 0
         self.depth = np.array([0] * nqubit)
-        self.wires_measure = None
+        self.wires_measure = []
         self.wires_condition = []
 
     def set_init_state(self, init_state: Any) -> None:
@@ -264,7 +264,7 @@ class QubitCircuit(Operation):
         self.npara = 0
         self.ndata = 0
         self.depth = np.array([0] * self.nqubit)
-        self.wires_measure = None
+        self.wires_measure = []
         self.wires_condition = []
 
     def amplitude_encoding(self, data: Any) -> torch.Tensor:
@@ -491,7 +491,7 @@ class QubitCircuit(Operation):
         without_control_gates = (TGate, TDaggerGate, CNOT, Rxx, Ryy, Rzz, Toffoli, Fredkin, Barrier)
         single_control_gates = (U3Gate, PhaseShift, PauliY, PauliZ, Hadamard, SGate, SDaggerGate, Rx, Ry, Rz, Swap)
         qasm_lst = ['OPENQASM 2.0;\n' + 'include "qelib1.inc";\n']
-        if self.wires_measure is None and self.wires_condition == []:
+        if self.wires_measure == self.wires_condition == []:
             qasm_lst.append(f'qreg q[{self.nqubit}];\n')
         else:
             qasm_lst.append(f'qreg q[{self.nqubit}];\n' + f'creg c[{self.nqubit}];\n')
@@ -516,9 +516,8 @@ class QubitCircuit(Operation):
                         Gate._reset_qasm_new_gate()
                         raise ValueError(f'Too many control bits for {op.name}')
             qasm_lst.append(op._qasm())
-        if self.wires_measure is not None:
-            for wire in self.wires_measure:
-                qasm_lst.append(f'measure q[{wire}] -> c[{wire}];\n')
+        for wire in self.wires_measure:
+            qasm_lst.append(f'measure q[{wire}] -> c[{wire}];\n')
         Gate._reset_qasm_new_gate()
         return ''.join(qasm_lst)
 
@@ -526,15 +525,14 @@ class QubitCircuit(Operation):
         """Get QASM of the quantum circuit for visualization."""
         # pylint: disable=protected-access
         qasm_lst = ['OPENQASM 2.0;\n' + 'include "qelib1.inc";\n']
-        if self.wires_measure is None and self.wires_condition == []:
+        if self.wires_measure == self.wires_condition == []:
             qasm_lst.append(f'qreg q[{self.nqubit}];\n')
         else:
             qasm_lst.append(f'qreg q[{self.nqubit}];\n' + f'creg c[{self.nqubit}];\n')
         for op in self.operators:
             qasm_lst.append(op._qasm())
-        if self.wires_measure is not None:
-            for wire in self.wires_measure:
-                qasm_lst.append(f'measure q[{wire}] -> c[{wire}];\n')
+        for wire in self.wires_measure:
+            qasm_lst.append(f'measure q[{wire}] -> c[{wire}];\n')
         Gate._reset_qasm_new_gate()
         Channel._reset_qasm_new_gate()
         return ''.join(qasm_lst)

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -36,7 +36,7 @@ class QubitCircuit(Operation):
         mps (bool, optional): Whether to use matrix product state representation. Default: ``False``
         chi (int or None, optional): The bond dimension for matrix product state representation.
             Default: ``None``
-        shots (int, optional): The number of shots for measurement. Default: ``1024``
+        shots (int, optional): The number of shots for the measurement. Default: ``1024``
 
     Raises:
         AssertionError: If the type or dimension of ``init_state`` does not match ``nqubit`` or ``den_mat``.
@@ -294,7 +294,14 @@ class QubitCircuit(Operation):
         with_prob: bool = False,
         wires: Union[int, List[int], None] = None
     ) -> Union[Dict, List[Dict], None]:
-        """Measure the final state."""
+        """Measure the final state.
+
+        Args:
+            shots (int or None, optional): The number of shots for the measurement. Default: ``None`` (which means
+                ``self.shots``)
+            with_prob (bool, optional): Whether to show the true probability of the measurement. Default: ``False``
+            wires (int, List[int] or None, optional): The wires to measure. Default: ``None`` (which means all wires)
+        """
         assert not self.mps, 'Currently NOT supported.'
         if shots is None:
             shots = self.shots
@@ -310,7 +317,12 @@ class QubitCircuit(Operation):
                            den_mat=self.den_mat)
 
     def expectation(self, shots: Optional[int] = None) -> torch.Tensor:
-        """Get the expectation value according to the final state and ``observables``."""
+        """Get the expectation value according to the final state and ``observables``.
+
+        Args:
+            shots (int or None, optional): The number of shots for the expectation value.
+                Default: ``None`` (which means the exact and differentiable expectation value).
+        """
         assert len(self.observables) > 0, 'There is no observable'
         if isinstance(self.state, list):
             assert all(isinstance(i, torch.Tensor) for i in self.state), 'Invalid final state'

--- a/src/deepquantum/qmath.py
+++ b/src/deepquantum/qmath.py
@@ -631,6 +631,17 @@ def expectation(
     return expval
 
 
+def sample2expval(sample: Dict) -> torch.Tensor:
+    """Get the expectation value according to the measurement results."""
+    total = 0
+    exp = 0
+    for bitstring, ncount in sample.items():
+        coeff = (-1) ** (bitstring.count('1') % 2)
+        exp += ncount * coeff
+        total += ncount
+    return torch.tensor([exp / total])
+
+
 def meyer_wallach_measure(state_tsr: torch.Tensor) -> torch.Tensor:
     r"""Calculate Meyer-Wallach entanglement measure.
 


### PR DESCRIPTION
- `shots` can be set via initialization, `measure`, and `expectation`.
- If `expectation` specifies `shots`, the estimated value obtained by sampling will be returned.
For example:
```python
data = torch.randn(4)
cir = dq.QubitCircuit(4, shots=2048)
cir.rylayer(encode=True)
cir.cnot_ring()
cir.rxlayer()
cir.observable(0, 'y')
cir.observable([0,1], 'xy')
cir.observable([0,1,3], 'xyz')
state = cir.amplitude_encoding(torch.randn(2**4))
cir(data=data, state=state)
# cir(data)
print(cir.shots)
print(cir.measure())
print(cir.expectation())
print(cir.expectation(shots=10000))
print(cir.shots)
```