### PR TITLE
Support transpiling QubitCircuit to MBQC patterns

### DIFF
--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -534,6 +534,8 @@ class QubitCircuit(Operation):
         else:
             pattern = Pattern(nodes_state=self.nqubit, state=self.init_state.state)
         node_next = self.nqubit
+        cmds = nn.Sequential()
+        encoders = []
         for op in self.operators:
             assert isinstance(op, allowed_ops), f'{op.name} is NOT supported for MBQC pattern transpiler'
             assert len(op.controls) == 0, f'Control bits are NOT supported for MBQC pattern transpiler'
@@ -541,19 +543,20 @@ class QubitCircuit(Operation):
             nodes = [self.wire2node_dict[i] for i in op.wires]
             ancilla = [node_next + i for i in range(op.nancilla)]
             if isinstance(op, ParametricSingleGate):
-                cmds = op.pattern(nodes, ancilla, op.theta, op.requires_grad)
-                pattern.commands += cmds
-                for cmd in cmds:
-                    if op in self.encoders:
-                        pattern.encoders.append(cmd)
-                        pattern.ndata += cmd.npara
-                    else:
-                        pattern.npara += cmd.npara
+                cmds_op = op.pattern(nodes, ancilla, op.theta, op.requires_grad)
+                if op in self.encoders:
+                    encoders.append(cmds_op[op.idx_mbqc])
             else:
-                pattern.commands += op.pattern(nodes, ancilla)
+                cmds_op = op.pattern(nodes, ancilla)
+            cmds += cmds_op
             for wire, node in zip(op.wires, op.nodes):
                 self.wire2node_dict[wire] = node
             node_next += op.nancilla
+        for cmd in cmds:
+            if cmd in encoders:
+                pattern.add(cmd, encode=True)
+            else:
+                pattern.add(cmd)
         pattern.set_nodes_out_seq([self.wire2node_dict[i] for i in range(self.nqubit)])
         return pattern
 

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -18,7 +18,6 @@ from .gate import ParametricSingleGate
 from .gate import U3Gate, PhaseShift, PauliX, PauliY, PauliZ, Hadamard, SGate, SDaggerGate, TGate, TDaggerGate
 from .gate import Rx, Ry, Rz, ProjectionJ, CNOT, Swap, Rxx, Ryy, Rzz, Rxy, ReconfigurableBeamSplitter, Toffoli, Fredkin
 from .gate import UAnyGate, LatentGate, HamiltonianGate, Barrier
-from .layer import ParametricSingleLayer
 from .layer import Observable, U3Layer, XLayer, YLayer, ZLayer, HLayer, RxLayer, RyLayer, RzLayer, CnotLayer, CnotRing
 from .operation import Operation, Gate, Layer, Channel
 from .qmath import amplitude_encoding, measure, expectation
@@ -301,7 +300,7 @@ class QubitCircuit(Operation):
         wires: Union[int, List[int], None] = None
     ) -> Union[Dict, List[Dict], None]:
         """Measure the final state."""
-        assert not self.mps, 'Currently NOT supported'
+        assert not self.mps, 'Currently NOT supported.'
         if wires is None:
             wires = list(range(self.nqubit))
         self.wires_measure = self._convert_indices(wires)

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -535,6 +535,7 @@ class QubitCircuit(Operation):
                 pattern.add_graph(nodes_state=[i], state='zero')
         else:
             pattern = Pattern(nodes_state=self.nqubit, state=self.init_state.state)
+        pattern.reupload = self.reupload
         node_next = self.nqubit
         for op in self.operators:
             assert isinstance(op, allowed_ops), f'{op.name} is NOT supported for MBQC pattern transpiler'

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -41,6 +41,7 @@ class SingleGate(Gate):
         super().__init__(name=name, nqubit=nqubit, wires=wires, controls=controls, condition=condition,
                          den_mat=den_mat, tsr_mode=tsr_mode)
         assert len(self.wires) == 1
+        # MBQC
         self.nancilla = 2
 
     def get_unitary(self) -> torch.Tensor:
@@ -823,6 +824,7 @@ class PauliY(SingleGate):
         super().__init__(name='PauliY', nqubit=nqubit, wires=wires, controls=controls, condition=condition,
                          den_mat=den_mat, tsr_mode=tsr_mode)
         self.register_buffer('matrix', torch.tensor([[0, -1j], [1j, 0]]))
+        # MBQC
         self.nancilla = 4
 
     def _qasm(self) -> str:
@@ -961,6 +963,7 @@ class Hadamard(SingleGate):
         super().__init__(name='Hadamard', nqubit=nqubit, wires=wires, controls=controls, condition=condition,
                          den_mat=den_mat, tsr_mode=tsr_mode)
         self.register_buffer('matrix', torch.tensor([[1, 1], [1, -1]], dtype=torch.cfloat) / 2 ** 0.5)
+        # MBQC
         self.nancilla = 1
 
     def _qasm(self) -> str:
@@ -1274,7 +1277,8 @@ class Rx(ParametricSingleGate):
     ) -> None:
         super().__init__(name='Rx', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
-        self.idx_mbqc = 4 # index of the commands to encode
+        # MBQC
+        self.idx_enc = [4] # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1365,8 +1369,9 @@ class Ry(ParametricSingleGate):
     ) -> None:
         super().__init__(name='Ry', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
+        # MBQC
         self.nancilla = 4
-        self.idx_mbqc = 6 # index of the commands to encode
+        self.idx_enc = [6] # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1459,7 +1464,8 @@ class Rz(ParametricSingleGate):
     ) -> None:
         super().__init__(name='Rz', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
-        self.idx_mbqc = 3 # index of the commands to encode
+        # MBQC
+        self.idx_enc = [3] # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1745,6 +1751,7 @@ class CNOT(DoubleControlGate):
                                                      [0, 1, 0, 0],
                                                      [0, 0, 0, 1],
                                                      [0, 0, 1, 0]]) + 0j)
+        # MBQC
         self.nancilla = 2
 
     def _qasm(self) -> str:
@@ -2235,6 +2242,7 @@ class Toffoli(TripleGate):
                                                      [0, 0, 0, 0, 0, 1, 0, 0],
                                                      [0, 0, 0, 0, 0, 0, 0, 1],
                                                      [0, 0, 0, 0, 0, 0, 1, 0]]) + 0j)
+        # MBQC
         self.nancilla = 18
 
     def get_unitary(self) -> torch.Tensor:

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -1318,6 +1318,7 @@ class Rx(ParametricSingleGate):
         cmds.append(Correction(ancilla[1], basis='x', domain=ancilla[0]))
         cmds.append(Correction(ancilla[1], basis='z', domain=nodes))
         self.nodes = [ancilla[1]]
+        self.encoder = cmds[4]
         return cmds
 
 
@@ -1413,6 +1414,7 @@ class Ry(ParametricSingleGate):
         cmds.append(Correction(ancilla[3], basis='x', domain=[ancilla[0], ancilla[2]]))
         cmds.append(Correction(ancilla[3], basis='z', domain=[ancilla[0], ancilla[1]]))
         self.nodes = [ancilla[3]]
+        self.encoder = cmds[6]
         return cmds
 
 
@@ -1501,6 +1503,7 @@ class Rz(ParametricSingleGate):
         cmds.append(Correction(ancilla[1], basis='x', domain=ancilla[0]))
         cmds.append(Correction(ancilla[1], basis='z', domain=nodes))
         self.nodes = [ancilla[1]]
+        self.encoder = cmds[3]
         return cmds
 
 

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -1274,6 +1274,7 @@ class Rx(ParametricSingleGate):
     ) -> None:
         super().__init__(name='Rx', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
+        self.idx_mbqc = 4 # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1318,7 +1319,6 @@ class Rx(ParametricSingleGate):
         cmds.append(Correction(ancilla[1], basis='x', domain=ancilla[0]))
         cmds.append(Correction(ancilla[1], basis='z', domain=nodes))
         self.nodes = [ancilla[1]]
-        self.encoder = cmds[4]
         return cmds
 
 
@@ -1366,6 +1366,7 @@ class Ry(ParametricSingleGate):
         super().__init__(name='Ry', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
         self.nancilla = 4
+        self.idx_mbqc = 6 # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1414,7 +1415,6 @@ class Ry(ParametricSingleGate):
         cmds.append(Correction(ancilla[3], basis='x', domain=[ancilla[0], ancilla[2]]))
         cmds.append(Correction(ancilla[3], basis='z', domain=[ancilla[0], ancilla[1]]))
         self.nodes = [ancilla[3]]
-        self.encoder = cmds[6]
         return cmds
 
 
@@ -1459,6 +1459,7 @@ class Rz(ParametricSingleGate):
     ) -> None:
         super().__init__(name='Rz', inputs=inputs, nqubit=nqubit, wires=wires, controls=controls,
                          condition=condition, den_mat=den_mat, tsr_mode=tsr_mode, requires_grad=requires_grad)
+        self.idx_mbqc = 3 # index of the commands to encode
 
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
@@ -1503,7 +1504,6 @@ class Rz(ParametricSingleGate):
         cmds.append(Correction(ancilla[1], basis='x', domain=ancilla[0]))
         cmds.append(Correction(ancilla[1], basis='z', domain=nodes))
         self.nodes = [ancilla[1]]
-        self.encoder = cmds[3]
         return cmds
 
 

--- a/src/deepquantum/mbqc/__init__.py
+++ b/src/deepquantum/mbqc/__init__.py
@@ -7,4 +7,6 @@ from . import operation
 from . import pattern
 from . import state
 
+from .command import Node, Entanglement, Measurement, Correction
 from .pattern import Pattern
+from .state import SubGraphState, GraphState

--- a/src/deepquantum/mbqc/command.py
+++ b/src/deepquantum/mbqc/command.py
@@ -180,7 +180,8 @@ class Measurement(Command):
             self.register_buffer('angle', angle)
 
     def extra_repr(self) -> str:
-        s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle.item()}'
+        s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle}'
+        # s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle.item()}'
         return s + f', s_domain={self.s_domain}, t_domain={self.t_domain}'
 
 

--- a/src/deepquantum/mbqc/command.py
+++ b/src/deepquantum/mbqc/command.py
@@ -182,8 +182,7 @@ class Measurement(Command):
             self.register_buffer('angle', angle)
 
     def extra_repr(self) -> str:
-        s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle}'
-        # s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle.item()}'
+        s = super().extra_repr() + f', plane={self.plane.upper()}, angle={self.angle.item()}'
         return s + f', s_domain={self.s_domain}, t_domain={self.t_domain}'
 
 

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -55,7 +55,7 @@ class Pattern(Operation):
     def forward(
         self,
         data: Optional[torch.Tensor] = None,
-        state: Optional[GraphState] = None,
+        state: Optional[GraphState] = None
     ) -> GraphState:
         """Perform a forward pass of the MBQC pattern and return the final graph state.
 

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -25,12 +25,13 @@ class Pattern(Operation):
     Args:
         nodes_state (int, List[int] or None): The nodes of the input state in the subgraph.
             It can be an integer representing the number of nodes or a list of node indices.
-            Default: ``None``.
-        state (Any, optional): The initial state of the subgraph. Default: ``'plus'``.
+            Default: ``None``
+        state (Any, optional): The initial state of the subgraph. The string representation of state
+            could be ``'plus'``, ``'minus'``, ``'zero'``, and ``'one'``. Default: ``'plus'``
         edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-            Default: ``None``.
+            Default: ``None``
         nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-            Default: ``None``.
+            Default: ``None``
         name (str or None, optional): The name of the pattern. Default: ``None``
 
     Ref: V. Danos, E. Kashefi and P. Panangaden. J. ACM 54.2 8 (2007)

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -144,11 +144,14 @@ class Pattern(Operation):
         """
         if data is None:
             return
-        assert len(data) >= self.ndata
+        assert data.size(-1) >= self.ndata
         count = 0
         for op in self.encoders:
             count_up = count + op.npara
-            op.init_para(data[count:count_up])
+            if data.ndim == 2:
+                op.init_para(data[:,count:count_up])
+            else:
+                op.init_para(data[count:count_up])
             count = count_up % len(data)
 
     def n(self, node: Union[int, List[int]]):

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -234,7 +234,7 @@ class Pattern(Operation):
         edges_s_domain = []
         for op in self.commands:
             if isinstance(op, Node):
-                g.add_node(*op.nodes,layer=2)
+                g.add_nodes_from(op.nodes, layer=2)
             elif isinstance(op, Entanglement):
                 g.add_edge(*op.nodes)
             elif isinstance(op, Measurement):
@@ -261,8 +261,8 @@ class Pattern(Operation):
         plt.plot([], [], ':', color='#db1d2c', label='zflow')
         plt.plot([], [], 's', color='#1f78b4', label='input nodes')
         plt.plot([], [], 'o', color='#d7dde0', label='output nodes')
-        plt.xlim(-width/2,width/2)
-        plt.ylim(-width/2,width/2)
+        # plt.xlim(-width/2,width/2)
+        # plt.ylim(-width/2,width/2)
         plt.legend(loc='upper right', fontsize=10)
         plt.tight_layout()
         plt.show()

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -50,13 +50,13 @@ class Pattern(Operation):
         self.encoders = []
         self.npara = 0
         self.ndata = 0
-        self.final_wires2nodes_dict = None
+        self.nodes_out_seq = None
 
     def forward(
         self,
         data: Optional[torch.Tensor] = None,
         state: Optional[GraphState] = None,
-    ) -> torch.Tensor:
+    ) -> GraphState:
         """Perform a forward pass of the MBQC pattern and return the final graph state.
 
         Args:
@@ -72,8 +72,7 @@ class Pattern(Operation):
             self.state = state
         self.encode(data)
         self.state = self.commands(self.state)
-        if self.final_wires2nodes_dict is not None:
-            self.state.final_wires2nodes_dict = self.final_wires2nodes_dict
+        self.state.set_nodes_out_seq(self.nodes_out_seq)
         return self.state
 
     def add_graph(self,
@@ -104,6 +103,10 @@ class Pattern(Operation):
             return self.state.graph
         else:
             return self.init_state.graph
+
+    def set_nodes_out_seq(self, nodes: Optional[List[int]] = None) -> None:
+        """Set the output sequence of the nodes."""
+        self.nodes_out_seq = nodes
 
     def add(
         self,

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -144,6 +144,7 @@ class Pattern(Operation):
         """
         if data is None:
             return
+        # not yet for reuplaoding
         assert data.size(-1) >= self.ndata
         count = 0
         for op in self.encoders:
@@ -152,7 +153,7 @@ class Pattern(Operation):
                 op.init_para(data[:,count:count_up])
             else:
                 op.init_para(data[count:count_up])
-            count = count_up % len(data)
+            count = count_up % data.size(-1)
 
     def n(self, node: Union[int, List[int]]):
         """Add a new node to the pattern.

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -72,6 +72,10 @@ class Pattern(Operation):
         self.encode(data)
         self.state = self.commands(self.state)
         self.state.set_nodes_out_seq(self.nodes_out_seq)
+        if data is not None:
+            if data.ndim == 2:
+                # for plotting the last data
+                self.encode(data[-1])
         return self.state
 
     def encode(self, data: Optional[torch.Tensor]) -> None:

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -50,6 +50,7 @@ class Pattern(Operation):
         self.encoders = []
         self.npara = 0
         self.ndata = 0
+        self.final_wires2nodes_dict = None
 
     def forward(
         self,
@@ -71,6 +72,8 @@ class Pattern(Operation):
             self.state = state
         self.encode(data)
         self.state = self.commands(self.state)
+        if self.final_wires2nodes_dict is not None:
+            self.state.final_wires2nodes_dict = self.final_wires2nodes_dict
         return self.state
 
     def add_graph(self,

--- a/src/deepquantum/mbqc/state.py
+++ b/src/deepquantum/mbqc/state.py
@@ -21,12 +21,13 @@ class SubGraphState(nn.Module):
     Args:
         nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
             It can be an integer representing the number of nodes or a list of node indices.
-            Default: ``None``.
-        state (Any, optional): The initial state of the subgraph. Default: ``'plus'``.
+            Default: ``None``
+        state (Any, optional): The initial state of the subgraph. The string representation of state
+            could be ``'plus'``, ``'minus'``, ``'zero'``, and ``'one'``. Default: ``'plus'``
         edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-            Default: ``None``.
+            Default: ``None``
         nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-            Default: ``None``.
+            Default: ``None``
     """
     def __init__(
         self,
@@ -100,8 +101,15 @@ class SubGraphState(nn.Module):
     def set_state(self, state: Any = 'plus') -> None:
         """Set the quantum state of the subgraph."""
         nqubit = len(self.nodes_state)
-        if state == 'plus':
-            state = torch.tensor([1, 1]) / 2 ** 0.5 + 0j
+        if isinstance(state, str):
+            if state == 'plus':
+                state = torch.tensor([1, 1]) / 2 ** 0.5 + 0j
+            elif state == 'minus':
+                state = torch.tensor([1, -1]) / 2 ** 0.5 + 0j
+            elif state == 'zero':
+                state = torch.tensor([1, 0]) + 0j
+            elif state == 'one':
+                state = torch.tensor([0, 1]) + 0j
             if nqubit > 0:
                 state = multi_kron([state] * nqubit)
         elif not isinstance(state, torch.Tensor):

--- a/src/deepquantum/mbqc/state.py
+++ b/src/deepquantum/mbqc/state.py
@@ -37,10 +37,10 @@ class SubGraphState(nn.Module):
         nodes: Union[int, List[int], None] = None # primarily, for the single-node case
     ) -> None:
         super().__init__()
+        self.nodes_out_seq = None
         self.set_graph(nodes_state, edges, nodes)
         self.set_state(state)
         self.measure_dict = defaultdict(list) # record the measurement results: {node: batched_bit}
-        self.nodes_out_seq = None
 
     @property
     def nodes(self, **kwargs):
@@ -126,6 +126,7 @@ class SubGraphState(nn.Module):
             assert len(nodes) == len(self.nodes)
             assert set(nodes) == set(self.nodes)
         self.nodes_out_seq = nodes
+        self.update_node2wire_dict()
 
     def add_nodes(self, nodes: Union[int, List[int]]) -> None:
         """Add nodes to the subgraph."""
@@ -151,7 +152,7 @@ class SubGraphState(nn.Module):
 
         Args:
             other (SubGraphState): The other subgraph state to compose with.
-            relabel (bool, optional): Whether to relabel nodes to avoid conflicts. Default: ``True``.
+            relabel (bool, optional): Whether to relabel nodes to avoid conflicts. Default: ``True``
 
         Returns:
             SubGraphState: A new subgraph state that is the composition of the two.
@@ -198,12 +199,12 @@ class GraphState(nn.Module):
     Args:
         nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
             It can be an integer representing the number of nodes or a list of node indices.
-            Default: ``None``.
-        state (Any, optional): The initial state of the subgraph. Default: ``'plus'``.
+            Default: ``None``
+        state (Any, optional): The initial state of the subgraph. Default: ``'plus'``
         edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-            Default: ``None``.
+            Default: ``None``
         nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-            Default: ``None``.
+            Default: ``None``
     """
     def __init__(
         self,
@@ -226,7 +227,7 @@ class GraphState(nn.Module):
         state: Any = 'plus',
         edges: Optional[List] = None,
         nodes: Union[int, List[int], None] = None,
-        measure_dict: Dict = None,
+        measure_dict: Optional[Dict] = None,
         index: Optional[int] = None
     ) -> None:
         """Add a subgraph to the graph state.
@@ -234,14 +235,14 @@ class GraphState(nn.Module):
         Args:
             nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
                 It can be an integer representing the number of nodes or a list of node indices.
-                Default: ``None``.
-            state (Any, optional): The initial state of the subgraph. Default: ``'plus'``.
+                Default: ``None``
+            state (Any, optional): The initial state of the subgraph. Default: ``'plus'``
             edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-                Default: ``None``.
+                Default: ``None``
             nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-                Default: ``None``.
-            measure_dict (Dict or None, optional): A dictionary to record measurement results. Default: ``None``.
-            index (int or None, optional): The index where to insert the subgraph. Default: ``None``.
+                Default: ``None``
+            measure_dict (Dict or None, optional): A dictionary to record measurement results. Default: ``None``
+            index (int or None, optional): The index where to insert the subgraph. Default: ``None``
         """
         sgs = SubGraphState(nodes_state, state, edges, nodes)
         if measure_dict is not None:

--- a/src/deepquantum/mbqc/state.py
+++ b/src/deepquantum/mbqc/state.py
@@ -19,15 +19,12 @@ class SubGraphState(nn.Module):
     """A subgraph state of a quantum state.
 
     Args:
-        nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
-            It can be an integer representing the number of nodes or a list of node indices.
-            Default: ``None``
-        state (Any, optional): The initial state of the subgraph. The string representation of state
+        nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph state.
+            It can be an integer representing the number of nodes or a list of node indices. Default: ``None``
+        state (Any, optional): The input state of the subgraph state. The string representation of state
             could be ``'plus'``, ``'minus'``, ``'zero'``, and ``'one'``. Default: ``'plus'``
-        edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-            Default: ``None``
-        nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-            Default: ``None``
+        edges (List or None, optional): Additional edges connecting the nodes in the subgraph state. Default: ``None``
+        nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph state. Default: ``None``
     """
     def __init__(
         self,
@@ -54,7 +51,7 @@ class SubGraphState(nn.Module):
 
     @property
     def full_state(self) -> torch.Tensor:
-        """Compute and return the full quantum state of the subgraph."""
+        """Compute and return the full quantum state of the subgraph state."""
         nqubit = len(self.nodes)
         nodes_bg = list(self.nodes)
         for i in self.nodes_state:
@@ -100,7 +97,7 @@ class SubGraphState(nn.Module):
         self.update_node2wire_dict()
 
     def set_state(self, state: Any = 'plus') -> None:
-        """Set the quantum state of the subgraph."""
+        """Set the input state of the subgraph state."""
         nqubit = len(self.nodes_state)
         if isinstance(state, str):
             if state == 'plus':
@@ -129,14 +126,14 @@ class SubGraphState(nn.Module):
         self.update_node2wire_dict()
 
     def add_nodes(self, nodes: Union[int, List[int]]) -> None:
-        """Add nodes to the subgraph."""
+        """Add nodes to the subgraph state."""
         if isinstance(nodes, int):
             nodes = [nodes]
         self.graph.add_nodes_from(nodes)
         self.update_node2wire_dict()
 
     def add_edges(self, edges: List) -> None:
-        """Add edges to the subgraph."""
+        """Add edges to the subgraph state."""
         self.graph.add_edges_from(edges, cz=True)
         self.update_node2wire_dict()
 
@@ -189,7 +186,6 @@ class SubGraphState(nn.Module):
         nx.draw(self.graph, with_labels=True, **kwargs)
 
     def extra_repr(self) -> str:
-        """Return a string representation of the subgraph state."""
         return f'nodes_state={self.nodes_state}, nodes={self.nodes}'
 
 
@@ -197,13 +193,13 @@ class GraphState(nn.Module):
     """A graph state composed by several SubGraphStates.
 
     Args:
-        nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
-            It can be an integer representing the number of nodes or a list of node indices.
+        nodes_state (int, List[int] or None, optional): The nodes of the input state in the initial graph state.
+            It can be an integer representing the number of nodes or a list of node indices. Default: ``None``
+        state (Any, optional): The input state of the initial graph state. The string representation of state
+            could be ``'plus'``, ``'minus'``, ``'zero'``, and ``'one'``. Default: ``'plus'``
+        edges (List or None, optional): Additional edges connecting the nodes in the initial graph state.
             Default: ``None``
-        state (Any, optional): The initial state of the subgraph. Default: ``'plus'``
-        edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
-            Default: ``None``
-        nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
+        nodes (int, List[int] or None, optional): Additional nodes to include in the initial graph state.
             Default: ``None``
     """
     def __init__(
@@ -230,19 +226,19 @@ class GraphState(nn.Module):
         measure_dict: Optional[Dict] = None,
         index: Optional[int] = None
     ) -> None:
-        """Add a subgraph to the graph state.
+        """Add a subgraph state to the graph state.
 
         Args:
-            nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph.
-                It can be an integer representing the number of nodes or a list of node indices.
+            nodes_state (int, List[int] or None, optional): The nodes of the input state in the subgraph state.
+                It can be an integer representing the number of nodes or a list of node indices. Default: ``None``
+            state (Any, optional): The input state of the subgraph state. The string representation of state
+                could be ``'plus'``, ``'minus'``, ``'zero'``, and ``'one'``. Default: ``'plus'``
+            edges (List or None, optional): Additional edges connecting the nodes in the subgraph state.
                 Default: ``None``
-            state (Any, optional): The initial state of the subgraph. Default: ``'plus'``
-            edges (List or None, optional): Additional edges connecting the nodes in the subgraph.
+            nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph state.
                 Default: ``None``
-            nodes (int, List[int] or None, optional): Additional nodes to include in the subgraph.
-                Default: ``None``
-            measure_dict (Dict or None, optional): A dictionary to record measurement results. Default: ``None``
-            index (int or None, optional): The index where to insert the subgraph. Default: ``None``
+            measure_dict (Dict or None, optional): A dictionary containing all measurement results. Default: ``None``
+            index (int or None, optional): The index where to insert the subgraph state. Default: ``None``
         """
         sgs = SubGraphState(nodes_state, state, edges, nodes)
         if measure_dict is not None:
@@ -254,7 +250,7 @@ class GraphState(nn.Module):
 
     @property
     def graph(self) -> SubGraphState:
-        """The combined graph of all subgraphs."""
+        """The combined graph state of all subgraph states."""
         graph = None
         for subgraph in self.subgraphs:
             if graph is None:

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -143,6 +143,9 @@ class Gate(Operation):
         super().__init__(name=name, nqubit=nqubit, wires=wires, den_mat=den_mat, tsr_mode=tsr_mode)
         self.controls = controls
         self.condition = condition
+        # MBQC
+        self.nodes = self.wires
+        self.nancilla = 1
 
     def get_matrix(self, inputs: Any) -> torch.Tensor:
         """Get the local unitary matrix."""

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -392,6 +392,8 @@ class Layer(Operation):
             wires = [[0]]
         self.wires = self._convert_indices(wires)
         self.gates = nn.Sequential()
+        # MBQC
+        self.nodes = copy(self.wires)
 
     def get_unitary(self) -> torch.Tensor:
         """Get the global unitary matrix."""
@@ -456,6 +458,15 @@ class Layer(Operation):
             # pylint: disable=protected-access
             lst.append(gate._qasm())
         return ''.join(lst)
+
+    def pattern(self, nodes: List[List[int]], ancilla: List[List[int]]) -> nn.Sequential:
+        """Get the MBQC pattern."""
+        assert len(nodes) == len(ancilla) == len(self.gates)
+        cmds = nn.Sequential()
+        for i, gate in enumerate(self.gates):
+            cmds.extend(gate.pattern(nodes[i], ancilla[i]))
+            self.nodes[i] = gate.nodes
+        return cmds
 
 
 class Channel(Operation):

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -92,7 +92,7 @@ class QumodeCircuit(Operation):
         self._nloss = 0
         self._state_expand = None
         self._all_fock_basis = None
-
+        # TDM
         self._if_delayloop = False
         self._nmode_tdm = self.nmode
         self._ntau_dict = defaultdict(list) # {wire: [tau1, tau2, ...]}

--- a/tests/test_mbqc_transpile.py
+++ b/tests/test_mbqc_transpile.py
@@ -1,0 +1,53 @@
+import deepquantum as dq
+import numpy as np
+import torch
+import random
+
+def test_random_circuit_transpilation():
+    # Create a circuit with random number of qubits (2-5)
+    n_qubits = random.randint(2, 5)
+    batch_size = random.randint(1,3)
+    init_state = torch.rand(batch_size, 2**n_qubits)
+    init_state = init_state / torch.norm(init_state, dim=-1, keepdim=True)  # normalize
+
+    cir = dq.QubitCircuit(n_qubits, init_state=init_state)
+
+    # Available single-qubit gates
+    single_gates = [
+        lambda q: cir.h(q),
+        lambda q: cir.x(q),
+        lambda q: cir.rx(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.ry(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.rz(q, inputs=torch.rand(1) * 2 * torch.pi)
+    ]
+
+    # Add random number of gates (3-10)
+    n_gates = random.randint(3, 10)
+
+    for _ in range(n_gates):
+        # 70% chance for single-qubit gate, 30% for CNOT
+        if random.random() < 0.7:
+            # Random single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(single_gates)(qubit)
+        else:
+            # Random CNOT
+            control = random.randint(0, n_qubits-1)
+            target = random.randint(0, n_qubits-1)
+            # Ensure control and target are different
+            while target == control:
+                target = random.randint(0, n_qubits-1)
+            cir.cnot(control=control, target=target)
+
+    # Transpile circuit to measurement pattern
+    pattern = cir.pattern()
+
+    # Execute both circuits
+    state_cir = cir()
+    state_pattern = pattern()
+    # Assert that both states are equal (up to global phase)
+    assert torch.allclose(
+        torch.abs(state_cir),
+        torch.abs(state_pattern.graph.full_state),
+        atol=1e-6
+    )

--- a/tests/test_mbqc_transpile.py
+++ b/tests/test_mbqc_transpile.py
@@ -1,7 +1,9 @@
-import deepquantum as dq
-import numpy as np
-import torch
 import random
+
+import deepquantum as dq
+import pytest
+import torch
+
 
 def test_random_circuit_transpilation():
     # Create a circuit with random number of qubits (2-5)
@@ -51,6 +53,7 @@ def test_random_circuit_transpilation():
         torch.abs(state_pattern.graph.full_state),
         atol=1e-6
     )
+
 
 def test_encode_transpilation():
     # Create a circuit with random number of qubits (2-5)
@@ -114,6 +117,7 @@ def test_encode_transpilation():
         atol=1e-6
     )
 
+
 def test_batch_data_transpilation():
     # Create a circuit with random number of qubits (2-5)
     n_qubits = random.randint(2, 5)
@@ -176,6 +180,7 @@ def test_batch_data_transpilation():
         torch.abs(state_pattern),
         atol=1e-6
     )
+
 
 def test_data_reupload_transpilation():
     # Create a circuit with random number of qubits (2-5)

--- a/tests/test_mbqc_transpile.py
+++ b/tests/test_mbqc_transpile.py
@@ -51,3 +51,129 @@ def test_random_circuit_transpilation():
         torch.abs(state_pattern.graph.full_state),
         atol=1e-6
     )
+
+def test_encode_transpilation():
+    # Create a circuit with random number of qubits (2-5)
+    n_qubits = random.randint(2, 5)
+    batch_size = random.randint(1,3)
+    init_state = torch.rand(batch_size, 2**n_qubits)
+    init_state = init_state / torch.norm(init_state, dim=-1, keepdim=True)  # normalize
+
+    cir = dq.QubitCircuit(n_qubits, init_state=init_state)
+
+    # Available single-qubit gates
+    single_gates = [
+        lambda q: cir.h(q),
+        lambda q: cir.x(q),
+        lambda q: cir.rx(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.ry(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.rz(q, inputs=torch.rand(1) * 2 * torch.pi)
+    ]
+
+    parametric_single_gates = [
+    lambda q: cir.rx(q, encode=True),
+    lambda q: cir.ry(q, encode=True),
+    lambda q: cir.rz(q, encode=True)
+    ]
+
+    # Add random number of gates (3-10)
+    n_gates = random.randint(3, 10)
+    n_para = 0
+
+    for _ in range(n_gates):
+        random_number = random.random()
+        if random_number < 0.3:
+            # Random single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(single_gates)(qubit)
+        elif random_number < 0.8:
+            # Random parametric-single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(parametric_single_gates)(qubit)
+            n_para += 1
+        else:
+            # Random CNOT
+            control = random.randint(0, n_qubits-1)
+            target = random.randint(0, n_qubits-1)
+            # Ensure control and target are different
+            while target == control:
+                target = random.randint(0, n_qubits-1)
+            cir.cnot(control=control, target=target)
+
+    # Transpile circuit to measurement pattern
+    pattern = cir.pattern()
+    # prepare batched input data
+    para = torch.randn(n_para)
+    # Execute both circuits
+    state_cir = cir(data=para)
+    state_pattern = pattern(data=-para)
+    # Assert that both states are equal (up to global phase)
+    assert torch.allclose(
+        torch.abs(state_cir),
+        torch.abs(state_pattern.graph.full_state),
+        atol=1e-6
+    )
+
+def test_batch_data_transpilation():
+    # Create a circuit with random number of qubits (2-5)
+    n_qubits = random.randint(2, 5)
+    batch_size = random.randint(1,3)
+    init_state = torch.rand(2**n_qubits)
+    # init_state = torch.rand(batch_size, 2**n_qubits)
+    init_state = init_state / torch.norm(init_state, dim=-1, keepdim=True)  # normalize
+
+    cir = dq.QubitCircuit(n_qubits, init_state=init_state)
+
+    # Available single-qubit gates
+    single_gates = [
+        lambda q: cir.h(q),
+        lambda q: cir.x(q),
+        lambda q: cir.rx(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.ry(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.rz(q, inputs=torch.rand(1) * 2 * torch.pi)
+    ]
+
+    parametric_single_gates = [
+    lambda q: cir.rx(q, encode=True),
+    lambda q: cir.ry(q, encode=True),
+    lambda q: cir.rz(q, encode=True)
+    ]
+
+    # Add random number of gates (3-10)
+    n_gates = 4
+    # n_gates = random.randint(3, 10)
+    n_para = 0
+
+    for _ in range(n_gates):
+        random_number = random.random()
+        if random_number < 0.3:
+            # Random single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(single_gates)(qubit)
+        elif random_number < 0.8:
+            # Random parametric-single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(parametric_single_gates)(qubit)
+            n_para += 1
+        else:
+            # Random CNOT
+            control = random.randint(0, n_qubits-1)
+            target = random.randint(0, n_qubits-1)
+            # Ensure control and target are different
+            while target == control:
+                target = random.randint(0, n_qubits-1)
+            cir.cnot(control=control, target=target)
+
+    # Transpile circuit to measurement pattern
+    pattern = cir.pattern()
+    # prepare batched input data
+    para = torch.randn(batch_size, n_para)
+    # Execute both circuits
+    state_cir = cir(data=para)
+    state_pattern = pattern(data=-para).graph.full_state
+    # Assert that both states are equal (up to global phase)
+    assert torch.allclose(
+        torch.abs(state_cir),
+        torch.abs(state_pattern),
+        atol=1e-6
+    )

--- a/tests/test_mbqc_transpile.py
+++ b/tests/test_mbqc_transpile.py
@@ -176,3 +176,69 @@ def test_batch_data_transpilation():
         torch.abs(state_pattern),
         atol=1e-6
     )
+
+def test_data_reupload_transpilation():
+    # Create a circuit with random number of qubits (2-5)
+    n_qubits = random.randint(2, 5)
+    batch_size = random.randint(1,3)
+    init_state = torch.rand(2**n_qubits)
+    # init_state = torch.rand(batch_size, 2**n_qubits)
+    init_state = init_state / torch.norm(init_state, dim=-1, keepdim=True)  # normalize
+
+    cir = dq.QubitCircuit(n_qubits, init_state=init_state, reupload=True)
+
+    # Available single-qubit gates
+    single_gates = [
+        lambda q: cir.h(q),
+        lambda q: cir.x(q),
+        lambda q: cir.rx(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.ry(q, inputs=torch.rand(1) * 2 * torch.pi),
+        lambda q: cir.rz(q, inputs=torch.rand(1) * 2 * torch.pi)
+    ]
+
+    parametric_single_gates = [
+    lambda q: cir.rx(q, encode=True),
+    lambda q: cir.ry(q, encode=True),
+    lambda q: cir.rz(q, encode=True)
+    ]
+
+    # Add random number of gates (3-10)
+    n_gates = random.randint(6, 10)
+    n_para = 0
+
+    for _ in range(n_gates):
+        random_number = random.random()
+        if random_number < 0.3:
+            # Random single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(single_gates)(qubit)
+        elif random_number < 0.8:
+            # Random parametric-single-qubit gate
+            qubit = random.randint(0, n_qubits-1)
+            random.choice(parametric_single_gates)(qubit)
+            n_para += 1
+        else:
+            # Random CNOT
+            control = random.randint(0, n_qubits-1)
+            target = random.randint(0, n_qubits-1)
+            # Ensure control and target are different
+            while target == control:
+                target = random.randint(0, n_qubits-1)
+            cir.cnot(control=control, target=target)
+
+    # Transpile circuit to measurement pattern
+    pattern = cir.pattern()
+    # prepare batched input data
+    if n_para > 3:
+        para = torch.randn(batch_size, n_para-2)
+    else:
+        para = torch.randn(batch_size, n_para)
+    # Execute both circuits
+    state_cir = cir(data=para)
+    state_pattern = pattern(data=-para).graph.full_state
+    # Assert that both states are equal (up to global phase)
+    assert torch.allclose(
+        torch.abs(state_cir),
+        torch.abs(state_pattern),
+        atol=1e-6
+    )

--- a/tests/test_mbqc_transpile.py
+++ b/tests/test_mbqc_transpile.py
@@ -140,8 +140,7 @@ def test_batch_data_transpilation():
     ]
 
     # Add random number of gates (3-10)
-    n_gates = 4
-    # n_gates = random.randint(3, 10)
+    n_gates = random.randint(3, 10)
     n_para = 0
 
     for _ in range(n_gates):


### PR DESCRIPTION
For example:
```python
data = torch.randn(2)
cir = dq.QubitCircuit(2)
cir.hlayer()
cir.rylayer(encode=True)
cir.cnot_ring()
cir.rzlayer()
print(abs(cir(data=data)))
pattern = cir.pattern()
print(abs(pattern(data=-data).graph.full_state))
```