### PR TITLE
Add Bosonic backend

### DIFF
--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -52,6 +52,6 @@ from .state import QubitState, MatrixProductState
 from .mbqc import Pattern
 
 from .photonic import permanent, takagi, hafnian, torontonian
-from .photonic import FockState, GaussianState
+from .photonic import FockState, GaussianState, NonGaussianState, CatState
 from .photonic import QumodeCircuit, QumodeCircuitTDM, Clements, GaussianBosonSampling
 from .photonic import UnitaryMapper, UnitaryDecomposer, DrawClements

--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -52,6 +52,6 @@ from .state import QubitState, MatrixProductState
 from .mbqc import Pattern
 
 from .photonic import permanent, takagi, hafnian, torontonian
-from .photonic import FockState, GaussianState, BosonicState, CatState
+from .photonic import FockState, GaussianState, BosonicState, CatState, GKPState
 from .photonic import QumodeCircuit, QumodeCircuitTDM, Clements, GaussianBosonSampling
 from .photonic import UnitaryMapper, UnitaryDecomposer, DrawClements

--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -52,6 +52,6 @@ from .state import QubitState, MatrixProductState
 from .mbqc import Pattern
 
 from .photonic import permanent, takagi, hafnian, torontonian
-from .photonic import FockState, GaussianState, NonGaussianState, CatState
+from .photonic import FockState, GaussianState, BosonicState, CatState
 from .photonic import QumodeCircuit, QumodeCircuitTDM, Clements, GaussianBosonSampling
 from .photonic import UnitaryMapper, UnitaryDecomposer, DrawClements

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -106,34 +106,9 @@ class QubitCircuit(Operation):
 
     def to(self, arg: Any) -> 'QubitCircuit':
         """Set dtype or device of the ``QubitCircuit``."""
-        if arg == torch.float:
-            self.init_state.to(torch.cfloat)
-            for op in self.operators:
-                if op.npara == 0:
-                    op.to(torch.cfloat)
-                elif op.npara > 0:
-                    op.to(torch.float)
-            for ob in self.observables:
-                if ob.npara == 0:
-                    ob.to(torch.cfloat)
-                elif ob.npara > 0:
-                    ob.to(torch.float)
-        elif arg == torch.double:
-            self.init_state.to(torch.cdouble)
-            for op in self.operators:
-                if op.npara == 0:
-                    op.to(torch.cdouble)
-                elif op.npara > 0:
-                    op.to(torch.double)
-            for ob in self.observables:
-                if ob.npara == 0:
-                    ob.to(torch.cdouble)
-                elif ob.npara > 0:
-                    ob.to(torch.double)
-        else:
-            self.init_state.to(arg)
-            self.operators.to(arg)
-            self.observables.to(arg)
+        self.init_state.to(arg)
+        self.operators.to(arg)
+        self.observables.to(arg)
         return self
 
     # pylint: disable=arguments-renamed

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -2307,11 +2307,30 @@ class HamiltonianGate(ArbitraryGate):
             minmax = self.get_minmax(hamiltonian)
         super().__init__(name=name, nqubit=nqubit, wires=wires, minmax=minmax, controls=controls,
                          den_mat=den_mat, tsr_mode=tsr_mode)
+        self.npara = 1
         self.requires_grad = requires_grad
         self.register_buffer('x', PauliX().matrix)
         self.register_buffer('y', PauliY().matrix)
         self.register_buffer('z', PauliZ().matrix)
         self.init_para([hamiltonian, t])
+
+    def to(self, arg: Any) -> 'HamiltonianGate':
+        """Set dtype or device of the ``HamiltonianGate``."""
+        if arg == torch.float:
+            self.x = self.x.to(torch.cfloat)
+            self.y = self.y.to(torch.cfloat)
+            self.z = self.z.to(torch.cfloat)
+            self.ham_tsr = self.ham_tsr.to(torch.cfloat)
+            self.t = self.t.to(torch.float)
+        elif arg == torch.double:
+            self.x = self.x.to(torch.cdouble)
+            self.y = self.y.to(torch.cdouble)
+            self.z = self.z.to(torch.cdouble)
+            self.ham_tsr = self.ham_tsr.to(torch.cdouble)
+            self.t = self.t.to(torch.double)
+        else:
+            super().to(arg)
+        return self
 
     def _convert_hamiltonian(self, hamiltonian: List) -> List[List]:
         """Convert and check the list representation of the Hamiltonian."""

--- a/src/deepquantum/mbqc/command.py
+++ b/src/deepquantum/mbqc/command.py
@@ -7,9 +7,9 @@ from typing import Any, Iterable, List, Optional, Union
 import torch
 from torch import nn
 
+from ..circuit import QubitCircuit
 from .operation import Command
 from .state import GraphState
-from ..circuit import QubitCircuit
 
 
 class Node(Command):

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -144,6 +144,22 @@ class Gate(Operation):
         self.controls = controls
         self.condition = condition
 
+    def to(self, arg: Any) -> 'Gate':
+        """Set dtype or device of the ``Gate``."""
+        if arg == torch.float:
+            if self.npara == 0:
+                self.matrix = self.matrix.to(torch.cfloat)
+            elif self.npara > 0:
+                super().to(torch.float)
+        elif arg == torch.double:
+            if self.npara == 0:
+                self.matrix = self.matrix.to(torch.cdouble)
+            elif self.npara > 0:
+                super().to(torch.double)
+        else:
+            super().to(arg)
+        return self
+
     def get_matrix(self, inputs: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
         return self.matrix

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -29,7 +29,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne
 from .qmath import permanent, takagi, xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature
-from .state import FockState, GaussianState
+from .state import FockState, GaussianState, NonGaussianState, CatState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian
 from .utils import set_hbar, set_kappa, set_perm_chunksize

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -29,7 +29,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne
 from .qmath import permanent, takagi, xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature
-from .state import FockState, GaussianState, NonGaussianState, CatState
+from .state import FockState, GaussianState, BosonicState, CatState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian
 from .utils import set_hbar, set_kappa, set_perm_chunksize

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -29,7 +29,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne
 from .qmath import permanent, takagi, xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature
-from .state import FockState, GaussianState, BosonicState, CatState
+from .state import FockState, GaussianState, BosonicState, CatState, GKPState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian
 from .utils import set_hbar, set_kappa, set_perm_chunksize

--- a/src/deepquantum/photonic/ansatz.py
+++ b/src/deepquantum/photonic/ansatz.py
@@ -10,9 +10,9 @@ import numpy as np
 import torch
 from scipy.optimize import root
 
+from ..qmath import is_unitary
 from .circuit import QumodeCircuit
 from .qmath import sort_dict_fock_basis, takagi
-from ..qmath import is_unitary
 from .state import FockState
 
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -784,7 +784,18 @@ class QumodeCircuit(Operation):
         else:
             operators = self.operators
             nmode = self.nmode
-        mean = init_mean.reshape(-1, 2 * nmode, 1)
+        mean = init_mean
+        if self.backend == 'gaussian':
+            mean = mean.reshape(-1, 2 * nmode, 1)
+        elif self.backend == 'bosonic':
+            if mean.ndim == 2:
+                mean = mean.unsqueeze(0).unsqueeze(-1)
+            elif mean.ndim == 3:
+                if mean.shape[-1] == 1:
+                    mean = mean.unsqueeze(0)
+                elif mean.shape[-1] == 2 * nmode:
+                    mean = mean.unsqueeze(-1)
+            assert mean.ndim == 4
         for op in operators:
             mean = op.get_symplectic().to(mean.dtype) @ mean + op.get_displacement()
         return mean

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -2149,7 +2149,7 @@ class QumodeCircuit(Operation):
         if inputs is not None:
             requires_grad = False
             if not isinstance(inputs, torch.Tensor):
-                inputs = torch.tensor(inputs)
+                inputs = torch.tensor(inputs, dtype=torch.float)
             theta = torch.arccos(inputs ** 0.5) * 2
         loss = PhotonLoss(inputs=theta, nmode=self.nmode, wires=wires, cutoff=self.cutoff,
                           requires_grad=requires_grad)
@@ -2173,7 +2173,7 @@ class QumodeCircuit(Operation):
         if inputs is not None:
             requires_grad = False
             if not isinstance(inputs, torch.Tensor):
-                inputs = torch.tensor(inputs)
+                inputs = torch.tensor(inputs, dtype=torch.float)
             t = 10 ** (-inputs / 10)
             theta = torch.arccos(t ** 0.5) * 2
         loss = PhotonLoss(inputs=theta, nmode=self.nmode, wires=wires, cutoff=self.cutoff,

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -359,6 +359,7 @@ class BeamSplitter(DoubleGate):
         # correspond to: U a U^+ = (u^*)^T @ a and U^+ a^+ U = u^* @ a^+
         matrix_xp = torch.cat([torch.cat([matrix.real, -matrix.imag], dim=-1),
                                torch.cat([matrix.imag,  matrix.real], dim=-1)], dim=-2).reshape(4, 4)
+        matrix_xp = matrix_xp.to(theta.device, theta.dtype)
         vector_xp = torch.zeros(4, 1, dtype=theta.dtype, device=theta.device)
         return matrix_xp, vector_xp
 

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -10,8 +10,8 @@ import torch
 from torch import nn
 
 import deepquantum.photonic as dqp
-from .operation import Gate, Delay
 from ..qmath import is_unitary
+from .operation import Gate, Delay
 
 
 class SingleGate(Gate):
@@ -857,6 +857,20 @@ class UAnyGate(Gate):
         assert is_unitary(unitary), 'Please check the unitary matrix'
         self.register_buffer('matrix', unitary)
         self.register_buffer('matrix_state', None)
+
+    def to(self, arg: Any) -> 'UAnyGate':
+        """Set dtype or device of the ``UAnyGate``."""
+        if arg == torch.float:
+            self.matrix = self.matrix.to(torch.cfloat)
+            if self.matrix_state is not None:
+                self.matrix_state = self.matrix_state.to(torch.cfloat)
+        elif arg == torch.double:
+            self.matrix = self.matrix.to(torch.cdouble)
+            if self.matrix_state is not None:
+                self.matrix_state = self.matrix_state.to(torch.cdouble)
+        else:
+            super().to(arg)
+        return self
 
     def get_matrix_state(self, matrix: torch.Tensor) -> torch.Tensor:
         """Get the local transformation matrix acting on Fock state tensors.

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -113,10 +113,10 @@ class Generaldyne(Operation):
             exp_factor = exp_factor.squeeze()
             reweights = torch.exp(-0.5 * exp_factor) / torch.sqrt(torch.linalg.det(2 * torch.pi * (cov_b + self.cov_m)))
             new_weight = weight * reweights
-            new_weight /= torch.sum(abs(new_weight))
-            idx_out = abs(new_weight) > 0
+            new_weight /= torch.sum(new_weight)
+            idx_out = abs(new_weight) > 1e-8
             cov_out = cov_out[idx_out]
-            cov_out = cov_out[idx_out]
+            mean_out = mean_out[idx_out]
             weight_out = new_weight[idx_out]
             return [cov_out, mean_out, weight_out]
 

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -95,7 +95,7 @@ class Generaldyne(Operation):
             exp_imag = torch.exp((rm - mean_b.real).mT @ torch.linalg.solve(cov_t, mean_b.imag) * 1j).squeeze()
             weight *= exp_real * prob_g * exp_imag
             weight /= weight.sum(dim=-1, keepdim=True)
-            mean_a = mean_a + cov_ab @ torch.linalg.solve(cov_t, rm - mean_b)
+            mean_a = mean_a + cov_ab.to(mean_b.dtype) @ torch.linalg.solve(cov_t.to(mean_b.dtype), rm - mean_b)
 
         mean_out = torch.zeros_like(mean)
         mean_out[..., idx_rest, :] = mean_a

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -106,65 +106,6 @@ class Generaldyne(Operation):
         elif len(x) == 3:
             return [cov_out, mean_out, weight]
 
-    @staticmethod
-    def _reject_sample(cov_i, mean_i, weight_i, shots, wires):
-        """
-        reject sample algorithm for bosonic state
-
-        see https://arxiv.org/abs/2103.05530
-        """
-        nmode = int(cov_i.shape[-1]/2)
-        indices = wires + [wire + nmode for wire in wires] # xxpp
-        indices = torch.tensor(indices)
-        vals = torch.zeros([shots, 2 * len(wires)])
-        cov_sub = cov_i[:, indices[:, None], indices]
-        mean_sub = mean_i[:, indices]
-        imag_means_ind = torch.where(mean_sub.imag.any(dim=1))[0]
-        nonneg_weights_ind = torch.where(torch.angle(weight_i) != torch.pi)[0]
-        combined_ind = torch.cat((imag_means_ind, nonneg_weights_ind))
-        ub_ind = torch.unique(combined_ind)
-        ub_weight = abs(weight_i)
-        if len(imag_means_ind) > 0:
-            imag_means = mean_sub[imag_means_ind].imag
-            imag_covs = cov_sub[imag_means_ind]
-            imag_exp_arg = imag_means.mT @ torch.linalg.solve(imag_covs.real, imag_means)
-            imag_prefactor = np.exp(0.5 * imag_exp_arg)
-            ub_weight[imag_means_ind] *= imag_prefactor.flatten()
-        ub_weight = ub_weight[ub_ind]
-        ub_weights_prob = ub_weight / ub_weight.sum()
-        for k in range(shots):
-            drawn = False
-            while not drawn:
-                random_ind = torch.multinomial(ub_weights_prob, 1).item()
-                peak_ind_sample = ub_ind[random_ind]
-                mean_sample = mean_sub[peak_ind_sample].real # complex mean
-                cov_sample = cov_sub[peak_ind_sample]
-                peak_sample = MultivariateNormal(mean_sample.squeeze(-1), cov_sample.real).sample([1])[0]
-                peak_sample = peak_sample.reshape(2 * len(wires), 1)
-                ## compare probs
-                diff_sample = peak_sample - mean_sub # complex
-                cov_sub = cov_sub.to(diff_sample)
-                exp_arg = diff_sample.mT @ torch.linalg.solve(cov_sub, diff_sample)
-                exp_arg = exp_arg.flatten()
-                ub_exp_arg = deepcopy(exp_arg)
-                if len(imag_means_ind) > 0:
-                    diff_sample_ub = peak_sample - mean_sub[imag_means_ind].real
-                    temp = diff_sample_ub.mT @ torch.linalg.solve(imag_covs.real, diff_sample_ub)
-                    temp = temp.to(ub_exp_arg.dtype)
-                    ub_exp_arg[imag_means_ind] = temp.flatten()
-                ub_exp_arg = ub_exp_arg[ub_ind]
-
-                prefactors = 1 / torch.sqrt(torch.linalg.det(2 * torch.pi * cov_sub))
-                prob_dist_val = torch.sum(weight_i * prefactors * torch.exp(-0.5 * exp_arg)) # f(x0)
-                prob_upbnd = torch.sum(ub_weight * prefactors[ub_ind] * torch.exp(-0.5 * ub_exp_arg)) # g(x0)
-                assert abs(prob_dist_val.imag) < 1e-6
-                assert abs(prob_upbnd.imag) < 1e-6
-                vertical_sample = torch.rand(1)[0] * prob_upbnd
-                if vertical_sample.real < prob_dist_val.real:
-                    drawn = True
-                    vals[k] = peak_sample.flatten() # xxpp order
-        return vals
-
 
 class Homodyne(Generaldyne):
     """Homodyne measurement.

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -82,6 +82,7 @@ class Generaldyne(Operation):
 
         if len(x) == 2: # Gaussian
             mean_m = MultivariateNormal(mean_b.squeeze(-1), cov_t).sample([1])[0] # (batch, 2 * nwire)
+            mean_a = mean_a + cov_ab @ torch.linalg.solve(cov_t, mean_m.unsqueeze(-1) - mean_b)
         elif len(x) == 3: # Bosonic
             weight = x[2]
             mean_m = sample_reject_bosonic(cov_b, mean_b, weight, self.cov_m, 1)[:, 0] # (batch, 2 * nwire)
@@ -94,8 +95,8 @@ class Generaldyne(Operation):
             exp_imag = torch.exp((rm - mean_b.real).mT @ torch.linalg.solve(cov_t, mean_b.imag) * 1j).squeeze()
             weight *= exp_real * prob_g * exp_imag
             weight /= weight.sum(dim=-1, keepdim=True)
+            mean_a = mean_a + cov_ab @ torch.linalg.solve(cov_t, rm - mean_b)
 
-        mean_a = mean_a + cov_ab @ torch.linalg.solve(cov_t, mean_m.unsqueeze(-1) - mean_b)
         mean_out = torch.zeros_like(mean)
         mean_out[..., idx_rest, :] = mean_a
 

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -2,6 +2,8 @@
 Photonic measurements
 """
 
+import numpy as np
+from copy import deepcopy
 from typing import Any, List, Optional, Union
 
 import torch
@@ -50,20 +52,46 @@ class Generaldyne(Operation):
         self.register_buffer('cov_m', cov_m)
         self.samples = None
 
-    def forward(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
+    def forward(self, x: List[torch.Tensor], shots: Optional[int] = None) -> List[torch.Tensor]:
         """Perform a forward pass for Gaussian states.
 
         See Quantum Continuous Variables: A Primer of Theoretical Methods (2024)
         by Alessio Serafini Eq.(5.143) and Eq.(5.144) in page 121
         """
-        cov, mean = x
+        cov, mean = x[:2]
         wires = torch.tensor(self.wires)
-        size = cov.size()
         idx = torch.cat([wires, wires + self.nmode]) # xxpp order
         idx_all = torch.arange(2 * self.nmode)
         mask = ~torch.isin(idx_all, idx)
         idx_rest = idx_all[mask]
+        cov_b  = cov[:, idx[:, None], idx]
+        mean_b = mean[:, idx]
 
+        if len(x) == 2:
+            mean_m = MultivariateNormal(mean_b.squeeze(-1), cov_b + self.cov_m).sample([1])[0] # (batch, 2 * nwire)
+            cov_out, mean_out = self.update_state(mean_m, x, idx, idx_rest)
+            x_out = [cov_out, mean_out]
+        if len(x) == 3:
+            weight = x[2]
+            mean_m = self._reject_sample(cov, mean, weight, shots, wires.tolist())
+            mean_m_copy = torch.stack([mean_m[0]] * len(x[2]))
+            cov_out, mean_out, weight_out = self.update_state(mean_m_copy, x, idx, idx_rest) # only take the first example to update
+            x_out = [cov_out, mean_out, weight_out]
+        self.samples = mean_m[:, :len(self.wires)] # xxpp order
+        return x_out
+
+    def update_state(
+        self,
+        mean_m: List[torch.Tensor],
+        x: List[torch.Tensor],
+        idx: torch.Tensor,
+        idx_rest: torch.Tensor
+    ) -> List[torch.Tensor]:
+        """
+        update the state after homodyne measuremnet
+        """
+        cov, mean = x[:2]
+        size = cov.size()
         cov_a  = cov[:, idx_rest[:, None], idx_rest]
         cov_b  = cov[:, idx[:, None], idx]
         cov_ab = cov[:, idx_rest[:, None], idx]
@@ -74,12 +102,82 @@ class Generaldyne(Operation):
         cov_out = torch.stack([torch.eye(size[-1], dtype=cov.dtype, device=cov.device)] * size[0])
         cov_out[:, idx_rest[:, None], idx_rest] = cov_a # update the total cov mat
 
-        mean_m = MultivariateNormal(mean_b.squeeze(-1), cov_b + self.cov_m).sample([1])[0] # (batch, 2 * nwire)
         mean_a = mean_a + cov_ab @ torch.linalg.solve(cov_b + self.cov_m, mean_m.unsqueeze(-1) - mean_b)
         mean_out = torch.zeros_like(mean)
         mean_out[:, idx_rest] = mean_a
-        self.samples = mean_m[:, :len(self.wires)] # xxpp order
-        return [cov_out, mean_out]
+        if len(x) == 2:
+            return [cov_out, mean_out]
+        if len(x) == 3: # update weight
+            weight = x[2]
+            exp_factor = (mean_m.unsqueeze(-1) - mean_b).mT @ torch.linalg.solve(cov_b + self.cov_m, mean_m.unsqueeze(-1) - mean_b)
+            exp_factor = exp_factor.squeeze()
+            reweights = torch.exp(-0.5 * exp_factor) / torch.sqrt(torch.linalg.det(2 * torch.pi * (cov_b + self.cov_m)))
+            new_weight = weight * reweights
+            new_weight /= torch.sum(abs(new_weight))
+            idx_out = abs(new_weight) > 0
+            cov_out = cov_out[idx_out]
+            cov_out = cov_out[idx_out]
+            weight_out = new_weight[idx_out]
+            return [cov_out, mean_out, weight_out]
+
+    @staticmethod
+    def _reject_sample(cov_i, mean_i, weight_i, shots, wires):
+        """
+        reject sample algorithm for bosonic state
+
+        see https://arxiv.org/abs/2103.05530
+        """
+        nmode = int(cov_i.shape[-1]/2)
+        indices = wires + [wire + nmode for wire in wires] # xxpp
+        indices = torch.tensor(indices)
+        vals = torch.zeros([shots, 2 * len(wires)])
+        cov_sub = cov_i[:, indices[:, None], indices]
+        mean_sub = mean_i[:, indices]
+        imag_means_ind = torch.where(mean_sub.imag.any(dim=1))[0]
+        nonneg_weights_ind = torch.where(torch.angle(weight_i) != torch.pi)[0]
+        combined_ind = torch.cat((imag_means_ind, nonneg_weights_ind))
+        ub_ind = torch.unique(combined_ind)
+        ub_weight = abs(weight_i)
+        if len(imag_means_ind) > 0:
+            imag_means = mean_sub[imag_means_ind].imag
+            imag_covs = cov_sub[imag_means_ind]
+            imag_exp_arg = imag_means.mT @ torch.linalg.solve(imag_covs.real, imag_means)
+            imag_prefactor = np.exp(0.5 * imag_exp_arg)
+            ub_weight[imag_means_ind] *= imag_prefactor.flatten()
+        ub_weight = ub_weight[ub_ind]
+        ub_weights_prob = ub_weight / ub_weight.sum()
+        for k in range(shots):
+            drawn = False
+            while not drawn:
+                random_ind = torch.multinomial(ub_weights_prob, 1).item()
+                peak_ind_sample = ub_ind[random_ind]
+                mean_sample = mean_sub[peak_ind_sample].real # complex mean
+                cov_sample = cov_sub[peak_ind_sample]
+                peak_sample = MultivariateNormal(mean_sample.squeeze(-1), cov_sample.real).sample([1])[0]
+                peak_sample = peak_sample.reshape(2 * len(wires), 1)
+                ## compare probs
+                diff_sample = peak_sample - mean_sub # complex
+                cov_sub = cov_sub.to(diff_sample)
+                exp_arg = diff_sample.mT @ torch.linalg.solve(cov_sub, diff_sample)
+                exp_arg = exp_arg.flatten()
+                ub_exp_arg = deepcopy(exp_arg)
+                if len(imag_means_ind) > 0:
+                    diff_sample_ub = peak_sample - mean_sub[imag_means_ind].real
+                    temp = diff_sample_ub.mT @ torch.linalg.solve(imag_covs.real, diff_sample_ub)
+                    temp = temp.to(ub_exp_arg.dtype)
+                    ub_exp_arg[imag_means_ind] = temp.flatten()
+                ub_exp_arg = ub_exp_arg[ub_ind]
+
+                prefactors = 1 / torch.sqrt(torch.linalg.det(2 * torch.pi * cov_sub))
+                prob_dist_val = torch.sum(weight_i * prefactors * torch.exp(-0.5 * exp_arg)) # f(x0)
+                prob_upbnd = torch.sum(ub_weight * prefactors[ub_ind] * torch.exp(-0.5 * ub_exp_arg)) # g(x0)
+                assert abs(prob_dist_val.imag) < 1e-6
+                assert abs(prob_upbnd.imag) < 1e-6
+                vertical_sample = torch.rand(1)[0] * prob_upbnd
+                if vertical_sample.real < prob_dist_val.real:
+                    drawn = True
+                    vals[k] = peak_sample.flatten() # xxpp order
+        return vals
 
 
 class Homodyne(Generaldyne):
@@ -144,13 +242,16 @@ class Homodyne(Generaldyne):
         else:
             self.register_buffer('phi', phi)
 
-    def forward(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
+    def forward(self, x: List[torch.Tensor], shots: Optional[int] = None) -> List[torch.Tensor]:
         """Perform a forward pass for Gaussian states."""
-        cov, mean = x
+        cov, mean = x[:2]
         r = PhaseShift(inputs=-self.phi, nmode=self.nmode, wires=self.wires, cutoff=self.cutoff)
         r.to(cov.dtype).to(cov.device)
         cov, mean = r([cov, mean])
-        return super().forward([cov, mean])
+        x_out = [cov, mean]
+        if len(x) == 3:
+            x_out.append(x[2])
+        return super().forward(x_out, shots)
 
     def extra_repr(self) -> str:
         return f'wires={self.wires}, phi={self.phi.item()}'

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -47,7 +47,7 @@ class Generaldyne(Operation):
             cutoff = 2
         super().__init__(name=name, nmode=nmode, wires=wires, cutoff=cutoff, noise=noise, mu=mu, sigma=sigma)
         if not isinstance(cov_m, torch.Tensor):
-            cov_m = torch.tensor(cov_m).reshape(-1, 2 * len(self.wires), 2 * len(self.wires))
+            cov_m = torch.tensor(cov_m, dtype=torch.float).reshape(-1, 2 * len(self.wires), 2 * len(self.wires))
         assert cov_m.shape[-2] == cov_m.shape[-1] == 2 * len(self.wires), 'The size of cov_m does not match the wires'
         self.register_buffer('cov_m', cov_m)
         self.samples = None

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -173,13 +173,13 @@ class Gate(Operation):
         d[np.ix_(wires)] = vector
         return d
 
-    def op_gaussian(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
-        """Perform a forward pass for Gaussian states."""
-        cov, mean = x
+    def op_cv(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
+        """Perform a forward pass for Gaussian (Bosonic) states."""
+        cov, mean = x[:2]
         sp_mat = self.get_symplectic()
         cov = sp_mat @ cov @ sp_mat.mT
         mean = sp_mat @ mean + self.get_displacement()
-        return [cov, mean]
+        return [cov, mean] + x[2:]
 
     def get_mpo(self) -> Tuple[List[torch.Tensor], int]:
         r"""Convert gate to MPO form with identities at empty sites.
@@ -259,7 +259,7 @@ class Gate(Operation):
             else:
                 return self.op_state_tensor(x)
         elif isinstance(x, list):
-            return self.op_gaussian(x)
+            return self.op_cv(x)
 
     def extra_repr(self) -> str:
         return f'wires={self.wires}'
@@ -305,13 +305,13 @@ class Channel(Operation):
         """Update the local transformation matrices X and Y acting on Gaussian states."""
         return self.matrix_x, self.matrix_y
 
-    def op_gaussian(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
-        """Perform a forward pass for Gaussian states.
+    def op_cv(self, x: List[torch.Tensor]) -> List[torch.Tensor]:
+        """Perform a forward pass for Gaussian (Bosonic) states.
 
         See Quantum Continuous Variables: A Primer of Theoretical Methods (2024)
         by Alessio Serafini Eq.(5.35-5.37) in page 90
         """
-        cov, mean = x
+        cov, mean = x[:2]
         local_x, local_y = self.update_transform_xy()
         assert local_x.shape[-2] == local_x.shape[-1] == 2 * len(self.wires), 'Invalid matrix shape.'
         assert local_y.shape[-2] == local_y.shape[-1] == 2 * len(self.wires), 'Invalid matrix shape.'
@@ -323,14 +323,14 @@ class Channel(Operation):
         mat_y[np.ix_(wires, wires)] = local_y
         cov = mat_x @ cov @ mat_x.mT + mat_y
         mean = mat_x @ mean
-        return [cov, mean]
+        return [cov, mean] + x[2:]
 
     def forward(self, x: Union[torch.Tensor, List[torch.Tensor]]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Perform a forward pass."""
         if isinstance(x, torch.Tensor):
             return self.op_den_mat(x)
         elif isinstance(x, list):
-            return self.op_gaussian(x)
+            return self.op_cv(x)
 
 
 class Delay(Operation):

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -178,7 +178,7 @@ class Gate(Operation):
         cov, mean = x[:2]
         sp_mat = self.get_symplectic()
         cov = sp_mat @ cov @ sp_mat.mT
-        mean = sp_mat @ mean + self.get_displacement()
+        mean = sp_mat.to(mean.dtype) @ mean + self.get_displacement()
         return [cov, mean] + x[2:]
 
     def get_mpo(self) -> Tuple[List[torch.Tensor], int]:

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -459,4 +459,5 @@ def sample_reject_bosonic(
         for i in batches_done:
             batches.remove(i)
         shots_tmp = shots - min(count_shots)
+        print(len(batches))
     return torch.stack(rst) # (batch, shots, 2 * nmode)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -274,36 +274,12 @@ def _photon_number_mean_var_bosonic(
     shape_mean = mean.shape
     cov = cov.reshape(*shape_cov[:2], 2, 2).reshape(-1, 2, 2)
     mean = mean.reshape(*shape_mean[:2], 2, 1).reshape(-1, 2, 1)
-    # weight = weight.unsqueeze(-1)
     exp_gaussian, var_gaussian = _photon_number_mean_var_gaussian(cov, mean)
     exp_gaussian = exp_gaussian.reshape(*shape_cov[:2])
     var_gaussian = var_gaussian.reshape(*shape_cov[:2])
     exp = (weight * exp_gaussian).sum(-1)
     var = (weight * var_gaussian).sum(-1) + (weight * exp_gaussian**2).sum(-1) - exp ** 2
     return exp, var
-
-def _photon_number_mean_var_bosonic_old(
-    covs: torch.Tensor,
-    means: torch.Tensor,
-    weights: torch.Tensor
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Get the expectation value and variance of the photon number for single-mode Bosonic states."""
-    coef = dqp.kappa ** 2 / dqp.hbar
-    covs = covs.reshape(-1, weights.shape[-1], 2, 2)
-    means = means.reshape(-1, weights.shape[-1], 2, 1)
-    batch = covs.shape[0]
-    exps = []
-    vars = []
-    for i in range(batch):
-        cov = covs[i]
-        mean = means[i]
-        exp = torch.sum(weights[i] * coef * (vmap(torch.trace)(cov) + (mean.mT @ mean).squeeze())) - 1 / 2
-        var = torch.sum(weights[i] * coef ** 2 * (vmap(torch.trace)(cov @ cov) + 2 * (mean.mT @ cov.to(mean.dtype) @ mean).squeeze()) * 2) - 1 / 4
-        var += torch.sum(weights[i] * (coef * (vmap(torch.trace)(cov) + (mean.mT @ mean).squeeze()) - 1 / 2)**2)
-        var -= exp ** 2
-        exps.append(exp)
-        vars.append(var)
-    return torch.tensor(exps), torch.tensor(vars)
 
 
 def photon_number_mean_var(

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -446,7 +446,7 @@ def sample_reject_bosonic(
         exp_imag = torch.exp((rm - mean_rest.real).mT @ torch.linalg.solve(cov_t, mean_rest.imag) * 1j).squeeze()
         # Eq.(70-71)
         p_r0 = (weight[batches] * exp_real[batches] * prob_g * exp_imag).sum(-1) # (shots, batch)
-        assert torch.allclose(p_r0.imag, torch.zeros(1, device=p_r0.device))
+        assert torch.allclose(p_r0.imag, p_r0.imag.new_zeros(1))
         idx_shots, idx_batch = torch.where((y0 <= p_r0.real))
         batches_done = []
         for i in range(len(batches)):

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -422,7 +422,7 @@ def sample_reject_bosonic(
     assert cov.ndim == mean.ndim == 4
     assert weight.ndim == 2
     batch = cov.shape[0]
-    rst = [torch.tensor([], device=cov.device)] * batch
+    rst = [cov.new_empty(0)] * batch
     batches = list(range(batch))
     count_shots = [0] * batch
     shots_tmp = shots
@@ -459,5 +459,4 @@ def sample_reject_bosonic(
         for i in batches_done:
             batches.remove(i)
         shots_tmp = shots - min(count_shots)
-        print(len(batches))
     return torch.stack(rst) # (batch, shots, 2 * nmode)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -422,7 +422,7 @@ def sample_reject_bosonic(
     assert cov.ndim == mean.ndim == 4
     assert weight.ndim == 2
     batch = cov.shape[0]
-    rst = [torch.tensor([])] * batch
+    rst = [torch.tensor([], device=cov.device)] * batch
     batches = list(range(batch))
     count_shots = [0] * batch
     shots_tmp = shots
@@ -446,7 +446,7 @@ def sample_reject_bosonic(
         exp_imag = torch.exp((rm - mean_rest.real).mT @ torch.linalg.solve(cov_t, mean_rest.imag) * 1j).squeeze()
         # Eq.(70-71)
         p_r0 = (weight[batches] * exp_real[batches] * prob_g * exp_imag).sum(-1) # (shots, batch)
-        assert torch.allclose(p_r0.imag, torch.zeros(1))
+        assert torch.allclose(p_r0.imag, torch.zeros(1, device=p_r0.device))
         idx_shots, idx_batch = torch.where((y0 <= p_r0.real))
         batches_done = []
         for i in range(len(batches)):

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -160,18 +160,18 @@ class GaussianState(nn.Module):
     r"""A Gaussian state of n modes, representing by covariance matrix and displacement vector.
 
     Args:
-        state (str or List): The Gaussian state. It can be a vacuum state with ``'vac'``, or arbitrary Gaussian states
-            with [``cov``, ``mean``]. ``cov`` and ``mean`` are the covariance matrix and the displacement vector
-            of the Gaussian state, respectively. Use ``xxpp`` convention and :math:`\hbar=2` by default.
+        state (str or List): The Gaussian state. It can be a vacuum state with ``'vac'``, or arbitrary Gaussian state
+            with ``[cov, mean]``. ``cov`` and ``mean`` are the covariance matrix and the displacement vector of
+            the Gaussian state, respectively. Use ``xxpp`` convention and :math:`\hbar=2` by default.
             Default: ``'vac'``
         nmode (int or None, optional): The number of modes in the state. Default: ``None``
-        cutoff (int, optional): The Fock space truncation. Default: 5
+        cutoff (int or None, optional): The Fock space truncation. Default: ``None``
     """
     def __init__(
         self,
         state: Union[str, List] = 'vac',
         nmode: Optional[int] = None,
-        cutoff: int = 5
+        cutoff: Optional[int] = None
     ) -> None:
         super().__init__()
         if state == 'vac':
@@ -197,6 +197,8 @@ class GaussianState(nn.Module):
         self.register_buffer('cov', cov)
         self.register_buffer('mean', mean)
         self.nmode = nmode
+        if cutoff is None:
+            cutoff = 5
         self.cutoff = cutoff
         self.is_pure = self.check_purity()
 
@@ -215,24 +217,24 @@ class BosonicState(nn.Module):
 
     Args:
         state (str or List): The Bosoncic state. It can be a vacuum state with ``'vac'``, or arbitrary
-            linear combinations of Gaussian states with [``cov``, ``mean``, ``weight``]. ``cov``,``mean``
-            and ``weight`` are the covariance matrices, the displacement vectors and the weights
-            of the Gaussian state, respectively. Use ``xxpp`` convention and :math:`\hbar=2` by default.
+            linear combinations of Gaussian states with ``[cov, mean, weight]``. ``cov``,``mean`` and ``weight`` are
+            the covariance matrices, the displacement vectors and the weights of the Gaussian states, respectively.
+            Use ``xxpp`` convention and :math:`\hbar=2` by default.
             Default: ``'vac'``
         nmode (int or None, optional): The number of modes in the state. Default: ``None``
-        cutoff (int, optional): The Fock space truncation. Default: 5
+        cutoff (int or None, optional): The Fock space truncation. Default: ``None``
     """
     def __init__(
         self,
         state: Union[str, List] = 'vac',
         nmode: Optional[int] = None,
-        cutoff: int = 5
+        cutoff: Optional[int] = None
     ) -> None:
         super().__init__()
         if state == 'vac':
             if nmode is None:
                 nmode = 1
-            cov = torch.eye(2 * nmode) * dqp.hbar / (4 * dqp.kappa ** 2) + 0j
+            cov = torch.eye(2 * nmode) * dqp.hbar / (4 * dqp.kappa ** 2)
             mean = torch.zeros(2 * nmode, 1) + 0j
             weight = torch.tensor([1]) + 0j
         elif isinstance(state, list):
@@ -260,6 +262,8 @@ class BosonicState(nn.Module):
         self.register_buffer('mean', mean)
         self.register_buffer('weight', weight)
         self.nmode = nmode
+        if cutoff is None:
+            cutoff = 5
         self.cutoff = cutoff
 
     def tensor_product(self, state: 'BosonicState') -> 'BosonicState':

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -14,8 +14,6 @@ from ..qmath import multi_kron
 from .gate import PhaseShift
 from .qmath import dirac_ket, xpxp_to_xxpp, xxpp_to_xpxp
 
-import itertools
-
 
 class FockState(nn.Module):
     """A Fock state of n modes, including Fock basis states and Fock state tensors.

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -183,9 +183,9 @@ class GaussianState(nn.Module):
             cov = state[0]
             mean = state[1]
             if not isinstance(cov, torch.Tensor):
-                cov = torch.tensor(cov)
+                cov = torch.tensor(cov, dtype=torch.float)
             if not isinstance(mean, torch.Tensor):
-                mean = torch.tensor(mean)
+                mean = torch.tensor(mean, dtype=torch.float)
             if nmode is None:
                 nmode = cov.shape[-1] // 2
         cov = cov.reshape(-1, 2 * nmode, 2 * nmode)
@@ -242,7 +242,7 @@ class BosonicState(nn.Module):
             mean = state[1]
             weight = state[2]
             if not isinstance(cov, torch.Tensor):
-                cov = torch.tensor(cov, dtype=torch.cfloat)
+                cov = torch.tensor(cov, dtype=torch.float)
             if not isinstance(mean, torch.Tensor):
                 mean = torch.tensor(mean, dtype=torch.cfloat)
             if not isinstance(weight, torch.Tensor):
@@ -417,11 +417,11 @@ class CatState(BosonicState):
         if theta is None:
             theta = torch.rand(1)[0] * 2 * torch.pi
         if not isinstance(r, torch.Tensor):
-            r = torch.tensor(r)
+            r = torch.tensor(r, dtype=torch.float)
         if not isinstance(theta, torch.Tensor):
-            theta = torch.tensor(theta)
+            theta = torch.tensor(theta, dtype=torch.float)
         if not isinstance(p, torch.Tensor):
-            p = torch.tensor(p)
+            p = torch.tensor(p, dtype=torch.long)
         real_part = r * torch.cos(theta)
         imag_part = r * torch.sin(theta)
         means = torch.sqrt(torch.tensor(2 * dqp.hbar)) * \
@@ -463,9 +463,9 @@ class GKPState(BosonicState):
     ) -> None:
         nmode = 1
         if not isinstance(epsilon, torch.Tensor):
-            epsilon = torch.tensor(epsilon)
+            epsilon = torch.tensor(epsilon, dtype=torch.float)
         if not isinstance(amp_cutoff, torch.Tensor):
-            amp_cutoff = torch.tensor(amp_cutoff)
+            amp_cutoff = torch.tensor(amp_cutoff, dtype=torch.float)
         self.epsilon = epsilon
         self.amp_cutoff = amp_cutoff
         exp_eps = torch.exp(-2 * epsilon)

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -205,13 +205,14 @@ class GaussianState(nn.Module):
 
 
 class NonGaussianState(nn.Module):
-    r"""A linear combination of Gaussian state of n modes, representing by covariance matrix, displacement vector and weights.
+    r"""A linear combination of Gaussian state of n modes, representing by covariance matrix, displacement vector and weight.
 
     Args:
-        state (str or List): The Gaussian state. It can be a vacuum state with ``'vac'``, or arbitrary Gaussian states
-            with [``cov``, ``mean``]. ``cov`` and ``mean`` are the covariance matrix and the displacement vector
-            of the Gaussian state, respectively. Use ``xxpp`` convention and :math:`\hbar=2` by default.
-            Default: ``'vac'``
+        state (str or List): A linear combination of Gaussian state. It can be a vacuum state with ``'vac'``,
+        or arbitrary linear combination of Gaussian states with [``cov``, ``mean``, ``weight``]. ``cov``,``mean``
+        and ``weight`` are the covariance matrix, the displacement vector and combination weight
+        of the Gaussian state, respectively. Use ``xxpp`` convention and :math:`\hbar=2` by default.
+        Default: ``'vac'``
         nmode (int or None, optional): The number of modes in the state. Default: ``None``
         cutoff (int, optional): The Fock space truncation. Default: 5
     """
@@ -223,7 +224,7 @@ class NonGaussianState(nn.Module):
     ) -> None:
         super().__init__()
         if state == 'vac':
-            assert nmode == 1, 'valid for single mode'
+            nmode = 1
             cov = torch.eye(2 * nmode) * dqp.hbar / (4 * dqp.kappa ** 2)
             mean = torch.zeros(2 * nmode, 1)
             weight = torch.tensor([1])

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -561,8 +561,8 @@ def combine_tensors(tensors: List[torch.Tensor], ndim_ds: int = 2) -> torch.Tens
 
     Args:
         tensors (List[torch.Tensor]): The list of 3D tensors to combine.
-        ndim_ds (int, optional): The dimension of direct sum. Use 1 for direct sum along rows.
-            Use 2 for direct sum along both rows and columns. Default: 2
+        ndim_ds (int, optional): The dimension of direct sum. Use 1 for direct sum along rows,
+            or use 2 for direct sum along both rows and columns. Default: 2
     """
     assert ndim_ds in (1, 2)
     # Get number of tensors and their shapes
@@ -617,5 +617,4 @@ def combine_bosonic_states(states: List[BosonicState], cutoff: Optional[int] = N
     cov = xpxp_to_xxpp(vmap(combine_tensors)(covs))
     mean = xpxp_to_xxpp(vmap(combine_tensors)(means, ndim_ds=1))
     weight = vmap(multi_kron)(weights)
-    return [cov, mean, weight]
-    # return BosonicState([cov, mean, weight], nmode, cutoff)
+    return BosonicState([cov, mean, weight], nmode, cutoff)

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -204,7 +204,7 @@ class GaussianState(nn.Module):
         return torch.allclose(purity, unity, rtol=rtol, atol=atol)
 
 
-class NonGaussianState(nn.Module):
+class BosonicState(nn.Module):
     r"""A linear combination of Gaussian state of n modes, representing by covariance matrix, displacement vector and weight.
 
     Args:
@@ -276,7 +276,7 @@ class NonGaussianState(nn.Module):
         batch = states[0].weight.shape[0]
         k = 0
         for s in states:
-            assert isinstance(s, NonGaussianState)
+            assert isinstance(s, BosonicState)
             covs.append(s.cov)
             means.append(s.mean)
             weights.append(s.weight)
@@ -309,7 +309,7 @@ class NonGaussianState(nn.Module):
         return [covs_, means_, weights_]
 
 
-class CatState(NonGaussianState):
+class CatState(BosonicState):
     r"""
     Cat state for single mode, The cat state is a non-Gaussian superposition of coherent states
 

--- a/src/deepquantum/photonic/tdm.py
+++ b/src/deepquantum/photonic/tdm.py
@@ -22,6 +22,8 @@ class QumodeCircuitTDM(QumodeCircuit):
             For Gaussian backend, it can be arbitrary Gaussian states with ``[cov, mean]``.
             Use ``xxpp`` convention and :math:`\hbar=2` by default.
         cutoff (int or None, optional): The Fock space truncation. Default: ``None``
+        backend (str, optional): Use ``'gaussian'`` for Gaussian backend or ``'bosonic'`` for Bosonic backend.
+            Default: ``'gaussian'``
         name (str or None, optional): The name of the circuit. Default: ``None``
         noise (bool, optional): Whether to introduce Gaussian noise. Default: ``False``
         mu (float, optional): The mean of Gaussian noise. Default: 0
@@ -32,15 +34,13 @@ class QumodeCircuitTDM(QumodeCircuit):
         nmode: int,
         init_state: Any,
         cutoff: Optional[int] = None,
-        backend: Optional[str] = None,
+        backend: str = 'gaussian',
         name: Optional[str] = None,
         noise: bool = False,
         mu: float = 0,
         sigma: float = 0.1
     ) -> None:
-        if backend is None:
-            backend = 'gaussian'
-        assert backend in ['gaussian', 'bosonic']
+        assert backend in ('gaussian', 'bosonic')
         super().__init__(nmode=nmode, init_state=init_state, cutoff=cutoff, backend=backend, basis=False,
                          detector='pnrd', name=name, mps=False, chi=None, noise=noise, mu=mu, sigma=sigma)
         self.samples = None

--- a/src/deepquantum/photonic/tdm.py
+++ b/src/deepquantum/photonic/tdm.py
@@ -32,12 +32,16 @@ class QumodeCircuitTDM(QumodeCircuit):
         nmode: int,
         init_state: Any,
         cutoff: Optional[int] = None,
+        backend: Optional[str] = None,
         name: Optional[str] = None,
         noise: bool = False,
         mu: float = 0,
         sigma: float = 0.1
     ) -> None:
-        super().__init__(nmode=nmode, init_state=init_state, cutoff=cutoff, backend='gaussian', basis=False,
+        if backend is None:
+            backend == 'gaussian'
+        assert backend in ['gaussian', 'bosonic']
+        super().__init__(nmode=nmode, init_state=init_state, cutoff=cutoff, backend=backend, basis=False,
                          detector='pnrd', name=name, mps=False, chi=None, noise=noise, mu=mu, sigma=sigma)
         self.samples = None
 

--- a/src/deepquantum/photonic/tdm.py
+++ b/src/deepquantum/photonic/tdm.py
@@ -39,7 +39,7 @@ class QumodeCircuitTDM(QumodeCircuit):
         sigma: float = 0.1
     ) -> None:
         if backend is None:
-            backend == 'gaussian'
+            backend = 'gaussian'
         assert backend in ['gaussian', 'bosonic']
         super().__init__(nmode=nmode, init_state=init_state, cutoff=cutoff, backend=backend, basis=False,
                          detector='pnrd', name=name, mps=False, chi=None, noise=noise, mu=mu, sigma=sigma)

--- a/src/deepquantum/state.py
+++ b/src/deepquantum/state.py
@@ -58,6 +58,16 @@ class QubitState(nn.Module):
                     state = state @ state.mH
                 self.register_buffer('state', state)
 
+    def to(self, arg: Any) -> 'QubitState':
+        """Set dtype or device of the ``QubitState``."""
+        if arg == torch.float:
+            self.state = self.state.to(torch.cfloat)
+        elif arg == torch.double:
+            self.state = self.state.to(torch.cdouble)
+        else:
+            self.state = self.state.to(arg)
+        return self
+
     def forward(self) -> None:
         """Pass."""
         pass
@@ -98,6 +108,18 @@ class MatrixProductState(nn.Module):
         self.normalize = normalize
         self.center = -1
         self.set_tensors(state)
+
+    def to(self, arg: Any) -> 'MatrixProductState':
+        """Set dtype or device of the ``MatrixProductState``."""
+        tensors = self.tensors
+        for i in range(self.nsite):
+            if arg == torch.float:
+                self._buffers[f'tensor{i}'] = tensors[i].to(torch.cfloat)
+            elif arg == torch.double:
+                self._buffers[f'tensor{i}'] = tensors[i].to(torch.cdouble)
+            else:
+                self._buffers[f'tensor{i}'] = tensors[i].to(arg)
+        return self
 
     @property
     def tensors(self) -> List[torch.Tensor]:

--- a/tests/test_photonic_bosonic.py
+++ b/tests/test_photonic_bosonic.py
@@ -30,8 +30,8 @@ def test_catstate():
 def test_forward_cov_mean():
     r = np.random.rand(1)[0]
     theta = 2*np.pi*np.random.rand(1)[0]
-    cat = dq.photonic.state.CatState(r=r, theta=theta, p=1)
-    vac  =dq.photonic.state.NonGaussianState(state='vac', nmode=1)
+    cat = dq.CatState(r=r, theta=theta, p=1)
+    vac  =dq.BosonicState(state='vac', nmode=1)
     cir = dq.QumodeCircuit(nmode=2, init_state=[cat, vac], backend='bosonic', cutoff=3)
     # cir.s(0, r=1.)
     angles = 2*np.pi*np.random.rand(2)

--- a/tests/test_photonic_bosonic.py
+++ b/tests/test_photonic_bosonic.py
@@ -23,7 +23,7 @@ def test_catstate():
     cat = dq.CatState(r=r, theta=theta, p=1)
     err1 = abs(cat.cov - covs_sf).sum()
     err2 = abs(cat.mean[0].squeeze() - means_sf).sum()
-    err3 = abs(cat.weight - weights_sf).sum()
+    err3 = abs(cat.weight - weights_sf).sum() / abs(weights_sf).sum() # relative error
     assert err1 + err2 + err3 < 3 * 1e-4
 
 
@@ -55,7 +55,7 @@ def test_forward_cov_mean():
     weights_sf = state.weights()
     err1 = abs(xxpp_to_xpxp(test[0][0]) - covs_sf).sum()
     err2 = abs(xxpp_to_xpxp(test[1][0]).squeeze() - means_sf).sum()
-    err3 = abs(test[2] - weights_sf).sum()
+    err3 = abs(test[2] - weights_sf).sum() / abs(weights_sf).sum() # relative error
     assert err1 + err2 + err3 < 3 * 1e-4
 
 

--- a/tests/test_photonic_bosonic.py
+++ b/tests/test_photonic_bosonic.py
@@ -84,5 +84,3 @@ def test_photon_number_mean_var():
     test2 = state.mean_photon(0)
     err = abs(torch.tensor(test1) - np.array(test2)).sum()
     assert err < 1e-5
-
-

--- a/tests/test_photonic_bosonic.py
+++ b/tests/test_photonic_bosonic.py
@@ -33,11 +33,9 @@ def test_forward_cov_mean():
     cat = dq.CatState(r=r, theta=theta, p=1)
     vac  =dq.BosonicState(state='vac', nmode=1)
     cir = dq.QumodeCircuit(nmode=2, init_state=[cat, vac], backend='bosonic', cutoff=3)
-    # cir.s(0, r=1.)
     angles = 2*np.pi*np.random.rand(2)
     cir.s(1, r=2.)
     cir.bs([0,1],  angles)
-    cir.to(torch.complex64)
     test = cir()
 
     nmodes = 2
@@ -69,17 +67,12 @@ def test_photon_number_mean_var():
         sf.ops.Catstate(a=r, phi=theta, p=1) | q[0] # superposition of 4 states
     eng = sf.Engine("bosonic", backend_options={"hbar": hbar}) #xpxp  order
     state = eng.run(prog_cat_bosonic).state
-    means_sf = state.means()
-    covs_sf = state.covs()
-    weights_sf = state.weights()
 
-    covs  = torch.tensor(covs_sf, dtype=torch.complex64)
-    means = torch.tensor(means_sf, dtype=torch.complex64).reshape(-1, 4, 1)
-    weights = torch.tensor(weights_sf, dtype=torch.complex64)
-    cir = dq.QumodeCircuit(nmode=1, init_state=[covs, means, weights], backend='bosonic', cutoff=3)
+    cir = dq.QumodeCircuit(nmode=1, init_state='vac', backend='bosonic', cutoff=3)
+    cir.cat(wires=0, r=r, theta=theta, p=1)
     cir.s(0, r=0)
-    cir.to(torch.complex64)
-    test = cir()
+    cir.to(torch.float)
+    cir()
     test1 = cir.photon_number_mean_var()
     test2 = state.mean_photon(0)
     err = abs(torch.tensor(test1) - np.array(test2)).sum()

--- a/tests/test_photonic_bosonic.py
+++ b/tests/test_photonic_bosonic.py
@@ -23,7 +23,7 @@ def test_catstate():
     cat = dq.CatState(r=r, theta=theta, p=1)
     err1 = abs(cat.cov - covs_sf).sum()
     err2 = abs(cat.mean[0].squeeze() - means_sf).sum()
-    err3 = abs(cat.weight-weights_sf).sum()
+    err3 = abs(cat.weight - weights_sf).sum()
     assert err1 + err2 + err3 < 3 * 1e-4
 
 
@@ -83,7 +83,7 @@ def test_photon_number_mean_var():
     test1 = cir.photon_number_mean_var()
     test2 = state.mean_photon(0)
     err = abs(torch.tensor(test1) - np.array(test2)).sum()
-    assert err < 1e-5
+    assert err < 1e-4
 
 def test_wigner():
     theta = 2*np.pi*np.random.rand(1)[0]
@@ -100,5 +100,5 @@ def test_wigner():
     pvec = torch.linspace(-5, 5, 200)
     w = state.wigner(0, qvec, pvec)
     test = gkp.wigner(wire=[0], qvec=qvec, pvec=pvec)
-    err = abs(test[0] - w).max()
+    err = abs(test[0].mT - w).max()
     assert err < 1e-5

--- a/tests/test_photonic_nongaussian.py
+++ b/tests/test_photonic_nongaussian.py
@@ -1,0 +1,88 @@
+import deepquantum as dq
+import numpy as np
+import pytest
+import strawberryfields as sf
+import torch
+
+from deepquantum.photonic import xxpp_to_xpxp
+
+def test_catstate():
+    r = np.random.rand(1)[0]
+    theta = 2*np.pi*np.random.rand(1)[0]
+    nmodes = 1
+    prog_cat_bosonic = sf.Program(nmodes)
+    hbar = 2
+    with prog_cat_bosonic.context as q:
+        sf.ops.Catstate(a=r, phi=theta, p=1) | q[0] # superposition of 4 states
+    eng = sf.Engine("bosonic", backend_options={"hbar": hbar}) # xpxp  order
+    state = eng.run(prog_cat_bosonic).state
+    means_sf = state.means()
+    covs_sf = state.covs()
+    weights_sf = state.weights()
+
+    cat = dq.CatState(r=r, theta=theta, p=1)
+    err1 = abs(cat.cov - covs_sf).sum()
+    err2 = abs(cat.mean[0].squeeze() - means_sf).sum()
+    err3 = abs(cat.weight-weights_sf).sum()
+    assert err1 + err2 + err3 < 3 * 1e-4
+
+
+def test_forward_cov_mean():
+    r = np.random.rand(1)[0]
+    theta = 2*np.pi*np.random.rand(1)[0]
+    cat = dq.photonic.state.CatState(r=r, theta=theta, p=1)
+    vac  =dq.photonic.state.NonGaussianState(state='vac', nmode=1)
+    cir = dq.QumodeCircuit(nmode=2, init_state=[cat, vac], backend='bosonic', cutoff=3)
+    # cir.s(0, r=1.)
+    angles = 2*np.pi*np.random.rand(2)
+    cir.s(1, r=2.)
+    cir.bs([0,1],  angles)
+    cir.to(torch.complex64)
+    test = cir()
+
+    nmodes = 2
+    prog_cat_bosonic = sf.Program(nmodes)
+    hbar = 2
+    with prog_cat_bosonic.context as q:
+        sf.ops.Catstate(a=r, phi=theta, p=1) | q[0] # superposition of 4 states
+    #     sf.ops.Squeezed(r=1) | q[0] # catstate 不能加压缩门
+        sf.ops.Squeezed(r=2) | q[1]
+        sf.ops.BSgate(angles[0], angles[1]) | [q[0], q[1]]
+    eng = sf.Engine("bosonic", backend_options={"hbar": hbar}) # xpxp  order
+    state = eng.run(prog_cat_bosonic).state
+    means_sf = state.means()
+    covs_sf = state.covs()
+    weights_sf = state.weights()
+    err1 = abs(xxpp_to_xpxp(test[0][0]) - covs_sf).sum()
+    err2 = abs(xxpp_to_xpxp(test[1][0]).squeeze() - means_sf).sum()
+    err3 = abs(test[2] - weights_sf).sum()
+    assert err1 + err2 + err3 < 3 * 1e-4
+
+
+def test_photon_number_mean_var():
+    r = np.random.rand(1)[0]
+    theta = 2*np.pi*np.random.rand(1)[0]
+    nmodes = 1
+    prog_cat_bosonic = sf.Program(nmodes)
+    hbar = 2
+    with prog_cat_bosonic.context as q:
+        sf.ops.Catstate(a=r, phi=theta, p=1) | q[0] # superposition of 4 states
+    eng = sf.Engine("bosonic", backend_options={"hbar": hbar}) #xpxp  order
+    state = eng.run(prog_cat_bosonic).state
+    means_sf = state.means()
+    covs_sf = state.covs()
+    weights_sf = state.weights()
+
+    covs  = torch.tensor(covs_sf, dtype=torch.complex64)
+    means = torch.tensor(means_sf, dtype=torch.complex64).reshape(-1, 4, 1)
+    weights = torch.tensor(weights_sf, dtype=torch.complex64)
+    cir = dq.QumodeCircuit(nmode=1, init_state=[covs, means, weights], backend='bosonic', cutoff=3)
+    cir.s(0, r=0)
+    cir.to(torch.complex64)
+    test = cir()
+    test1 = cir.photon_number_mean_var()
+    test2 = state.mean_photon(0)
+    err = abs(torch.tensor(test1) - np.array(test2)).sum()
+    assert err < 1e-5
+
+


### PR DESCRIPTION
1. support construct nongaussian state
```
cov = torch.stack([torch.eye(4)]*3)
mean = torch.tensor([[1,1,0,0],
                     [2,2,0,0],
                     [3,3,0,0]])
weight = torch.tensor([0.1, 0.4, 0.5])
state1 = dq.NonGaussianState([cov, mean, weight])
cat = dq.CatState(r=1.55, theta=0, p=1)
vac = dq.NonGaussianState(state='vac')
```

2. support forward for nongaussian state
```
cir = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=3, backend='bosonic')
cir.cat(wires=0, r=1, theta=0, p=1)
cir.gkp(wires=1, theta=0., phi=0.)
cir.s(0, 0.)
cir.s(1, 0.)
result = cir()
```

3. support non-gaussian state visulisation
```
gkp = dq.GKPState(theta=0., phi=0., amp_cutoff=0.01, epsilon=0.05)
qvec = torch.linspace(-8, 6, 100)
pvec = torch.linspace(-10, 7, 100)
test =gkp.wigner(0, qvec, pvec, plot=True)
```