### PR TITLE
Add non-Gaussian gates

### DIFF
--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -24,7 +24,8 @@ from .circuit import QumodeCircuit
 from .decompose import UnitaryDecomposer
 from .draw import DrawClements
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate
-from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum, DelayBS, DelayMZI
+from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum
+from .gate import QuadraticPhase, ControlledX, ControlledZ, CubicPhase, Kerr, CrossKerr, DelayBS, DelayMZI
 from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -20,7 +20,8 @@ from .channel import PhotonLoss
 from .decompose import UnitaryDecomposer
 from .draw import DrawCircuit
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate
-from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum, DelayBS, DelayMZI
+from .gate import Squeezing, Squeezing2, Displacement, DisplacementPosition, DisplacementMomentum
+from .gate import QuadraticPhase, ControlledX, ControlledZ, CubicPhase, Kerr, CrossKerr, DelayBS, DelayMZI
 from .hafnian_ import hafnian
 from .measurement import Homodyne
 from .operation import Operation, Gate, Channel, Delay
@@ -2141,6 +2142,126 @@ class QumodeCircuit(Operation):
         f = PhaseShift(inputs=theta, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
                        requires_grad=False, noise=self.noise, mu=mu, sigma=sigma)
         self.add(f)
+
+    def qp(
+        self,
+        wires: int,
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a quadratic phase gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        qp = QuadraticPhase(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                            requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(qp, encode=encode)
+
+    def cx(
+        self,
+        wires: List[int],
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a controlled-X gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        cx = ControlledX(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                         requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(cx, encode=encode)
+
+    def cz(
+        self,
+        wires: List[int],
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a controlled-Z gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        cz = ControlledZ(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                         requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(cz, encode=encode)
+
+    def cp(
+        self,
+        wires: int,
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a cubic phase gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        cp = CubicPhase(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                        requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(cp, encode=encode)
+
+    def k(
+        self,
+        wires: int,
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a Kerr gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        k = Kerr(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                 requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(k, encode=encode)
+
+    def ck(
+        self,
+        wires: List[int],
+        inputs: Any = None,
+        encode: bool = False,
+        mu: Optional[float] = None,
+        sigma: Optional[float] = None
+    ) -> None:
+        """Add a cross-Kerr gate."""
+        requires_grad = not encode
+        if inputs is not None:
+            requires_grad = False
+        if mu is None:
+            mu = self.mu
+        if sigma is None:
+            sigma = self.sigma
+        ck = CrossKerr(inputs=inputs, nmode=self.nmode, wires=wires, cutoff=self.cutoff, den_mat=self.den_mat,
+                       requires_grad=requires_grad, noise=self.noise, mu=mu, sigma=sigma)
+        self.add(ck, encode=encode)
 
     def delay(
         self,

--- a/src/deepquantum/photonic/draw.py
+++ b/src/deepquantum/photonic/draw.py
@@ -17,6 +17,7 @@ from .gate import QuadraticPhase, ControlledX, ControlledZ, CubicPhase, Kerr, Cr
 from .measurement import Homodyne
 from .operation import Delay
 
+
 info_dic = {'PS': ['teal', 0],
             'S': ['royalblue', 3],
             'S2': ['royalblue', 0],
@@ -28,6 +29,7 @@ info_dic = {'PS': ['teal', 0],
             'CX': ['gold', 0],
             'CZ': ['gold', 0],
             'CK': ['pink', 0]}
+
 
 class DrawCircuit():
     """Draw the photonic quantum circuit.

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -1632,15 +1632,15 @@ class QuadraticPhase(SingleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix(self, s: Any) -> torch.Tensor:
         """Get the local symplectic matrix acting on annihilation and creation operators."""
@@ -1801,15 +1801,15 @@ class ControlledX(DoubleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix(self, s: Any) -> torch.Tensor:
         """Get the local symplectic matrix acting on annihilation and creation operators."""
@@ -1835,7 +1835,7 @@ class ControlledX(DoubleGate):
         s = self.inputs_to_tensor(s).reshape(-1)
         zero = s.new_zeros(1)
         r = torch.arcsinh(-s / 2)
-        theta = torch.arccos(-torch.tanh(r)) / 2
+        theta = torch.atan2(-1 / torch.cosh(r), -torch.tanh(r)) / 2
         # noise already in s
         mat_bs1 = BeamSplitter([theta, zero], cutoff=self.cutoff).update_matrix_state()
         mat_s1 = Squeezing([r, zero], cutoff=self.cutoff).update_matrix_state()
@@ -1977,15 +1977,15 @@ class ControlledZ(DoubleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix(self, s: Any) -> torch.Tensor:
         """Get the local symplectic matrix acting on annihilation and creation operators."""
@@ -2012,7 +2012,7 @@ class ControlledZ(DoubleGate):
         theta = torch.tensor(torch.pi / 2, dtype=s.dtype, device=s.device)
         # noise already in s
         mat_ps1 = PhaseShift(-theta, cutoff=self.cutoff).update_matrix_state()
-        mat_cx = ControlledX(s, cutoff=self.cutoff).update_matrix()
+        mat_cx = ControlledX(s, cutoff=self.cutoff).update_matrix_state()
         mat_ps2 = PhaseShift(theta, cutoff=self.cutoff).update_matrix_state()
         mat = torch.einsum('an,mnkl,lb->makb', mat_ps2, mat_cx, mat_ps1)
         return mat
@@ -2106,15 +2106,15 @@ class CubicPhase(SingleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix_state(self, gamma: Any) -> torch.Tensor:
         """Get the local transformation matrix acting on Fock state tensors."""
@@ -2138,8 +2138,6 @@ class CubicPhase(SingleGate):
             self.gamma = nn.Parameter(gamma)
         else:
             self.register_buffer('gamma', gamma)
-        self.update_matrix()
-        self.update_transform_xp()
 
     def extra_repr(self) -> str:
         return f'wires={self.wires}, gamma={self.gamma.item()}'
@@ -2194,15 +2192,15 @@ class Kerr(SingleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix_state(self, kappa: Any) -> torch.Tensor:
         """Get the local transformation matrix acting on Fock state tensors."""
@@ -2225,8 +2223,6 @@ class Kerr(SingleGate):
             self.kappa = nn.Parameter(kappa)
         else:
             self.register_buffer('kappa', kappa)
-        self.update_matrix()
-        self.update_transform_xp()
 
     def extra_repr(self) -> str:
         return f'wires={self.wires}, kappa={self.kappa.item()}'
@@ -2285,15 +2281,15 @@ class CrossKerr(DoubleGate):
 
     def inputs_to_tensor(self, inputs: Any = None) -> torch.Tensor:
         """Convert inputs to torch.Tensor."""
+        while isinstance(inputs, list):
+            inputs = inputs[0]
         if inputs is None:
-            s = torch.rand(1)[0]
-        else:
-            s = inputs[0]
-        if not isinstance(s, torch.Tensor):
-            s = torch.tensor(s, dtype=torch.float)
+            inputs = torch.rand(1)[0]
+        if not isinstance(inputs, torch.Tensor):
+            inputs = torch.tensor(inputs, dtype=torch.float)
         if self.noise:
-            s = s + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
-        return s
+            inputs = inputs + torch.normal(self.mu, self.sigma, size=(1, )).squeeze()
+        return inputs
 
     def get_matrix_state(self, kappa: Any) -> torch.Tensor:
         """Get the local transformation matrix acting on Fock state tensors."""
@@ -2317,8 +2313,6 @@ class CrossKerr(DoubleGate):
             self.kappa = nn.Parameter(kappa)
         else:
             self.register_buffer('kappa', kappa)
-        self.update_matrix()
-        self.update_transform_xp()
 
     def extra_repr(self) -> str:
         return f'wires={self.wires}, kappa={self.kappa.item()}'

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -180,6 +180,13 @@ def fock_combinations(nmode: int, nphoton: int, cutoff: Optional[int] = None, na
     return result
 
 
+def ladder_ops(cutoff: int, dtype = torch.cfloat, device = 'cpu') -> Tuple[torch.Tensor, torch.Tensor]:
+    """Get the matrix representation of the annihilation and creation operators."""
+    sqrt = torch.arange(1, cutoff).to(dtype=dtype, device=device) ** 0.5
+    a = torch.diag(sqrt, diagonal=1)
+    ad = a.mH # share the memory
+    return a, ad
+
 def shift_func(l: List, nstep: int) -> List:
     """Shift a list by a number of steps.
 

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -187,6 +187,7 @@ def ladder_ops(cutoff: int, dtype = torch.cfloat, device = 'cpu') -> Tuple[torch
     ad = a.mH # share the memory
     return a, ad
 
+
 def shift_func(l: List, nstep: int) -> List:
     """Shift a list by a number of steps.
 

--- a/tests/test_with_xanadu.py
+++ b/tests/test_with_xanadu.py
@@ -146,7 +146,7 @@ def test_non_adjacent_bs_fock():
     result = eng.run(prog)
 
     nmode = n
-    cir = dq.QumodeCircuit(nmode=nmode, init_state=[1,1,1], cutoff=3, backend='fock', basis=True)
+    cir = dq.QumodeCircuit(nmode=nmode, init_state=[1,1,1], cutoff=4, backend='fock', basis=True)
     cir.ps(0, angles[0])
     cir.ps(1, angles[1])
     cir.bs([0,2], [angles[2], angles[3]])

--- a/tests/test_with_xanadu_gate.py
+++ b/tests/test_with_xanadu_gate.py
@@ -1,0 +1,119 @@
+import deepquantum as dq
+import numpy as np
+import strawberryfields as sf
+import torch
+from strawberryfields.ops import Pgate, CXgate, CZgate, Vgate, Kgate, CKgate
+
+
+def test_quadratic_phase_gate():
+    nmode = 1
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        Pgate(params[0]) | q[0]
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.qp(0, params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())
+
+
+def test_cx_gate():
+    nmode = 2
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        CXgate(params[0]) | (q[0], q[1])
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.cx([0,1], params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())
+
+
+def test_cz_gate():
+    nmode = 2
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        CZgate(params[0]) | (q[0], q[1])
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.cz([0,1], params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())
+
+
+def test_cubic_phase_gate():
+    nmode = 1
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        Vgate(params[0]) | q[0]
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.cp(0, params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())
+
+
+def test_kerr_gate():
+    nmode = 1
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        Kgate(params[0]) | q[0]
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.k(0, params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())
+
+
+def test_cross_kerr_gate():
+    nmode = 2
+    cutoff = 10
+    params = np.random.rand(1)
+
+    prog = sf.Program(nmode)
+    with prog.context as q:
+        CKgate(params[0]) | (q[0], q[1])
+    eng = sf.Engine('fock', backend_options={'cutoff_dim': cutoff})
+    result = eng.run(prog)
+
+    cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
+    cir.ck([0,1], params[0])
+    cir.to(torch.double)
+    state = cir()
+
+    assert np.allclose(result.state.data, state.numpy())


### PR DESCRIPTION
- Add `QuadraticPhase`, `ControlledX`, `ControlledZ`, `CubicPhase`, `Kerr`, and `CrossKerr`

For example:
```python
cir = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=3, backend='fock', basis=False)
cir.qp(0)
cir.cx([0,1])
cir.cz([0,1])
cir.cp(0)
cir.k(0)
cir.ck([0,1])
cir()
```