### PR TITLE
Fix 'sample_homodyne_fock' and 'wigner'

### DIFF
--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -369,7 +369,7 @@ def sample_homodyne_fock(
     h_terms = reduced_dm.unsqueeze(-1) * h_mat # (batch, cutoff, cutoff, nbin)
     probs = (h_terms.sum(dim=[-3, -2]) * torch.exp(-coef * xs**2)).real # (batch, nbin)
     probs = abs(probs)
-    probs[abs(probs) < 1e-10] = 0
+    probs[probs < 1e-10] = 0
     indices = torch.multinomial(probs.reshape(-1, nbin), num_samples=shots, replacement=True) # (batch, shots)
     samples = xs[indices]
     return samples.unsqueeze(-1) # (batch, shots, 1)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -368,6 +368,7 @@ def sample_homodyne_fock(
     h_mat = h_vals.reshape(1, cutoff, nbin) * h_vals.reshape(cutoff, 1, nbin) # (cutoff, cutoff, nbin)
     h_terms = reduced_dm.unsqueeze(-1) * h_mat # (batch, cutoff, cutoff, nbin)
     probs = (h_terms.sum(dim=[-3, -2]) * torch.exp(-coef * xs**2)).real # (batch, nbin)
+    probs = abs(probs)
     probs[abs(probs) < 1e-10] = 0
     indices = torch.multinomial(probs.reshape(-1, nbin), num_samples=shots, replacement=True) # (batch, shots)
     samples = xs[indices]

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -328,7 +328,8 @@ class BosonicState(nn.Module):
         gauss_b = MultivariateNormal(mean.squeeze(-1).real, cov) # mean shape: (batch, ncomb, 2)
         prob_g = gauss_b.log_prob(coords2).exp() # (npoints, batch, ncomb)
         exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov, mean.imag) / 2).squeeze() # (batch, ncomb)
-        # (batch, npoints, ncomb)
+        if exp_real.ndim == 0: # vacuum case
+            exp_real = exp_real.reshape(-1)
         exp_imag = torch.exp((coords3 - mean.real.unsqueeze(1)).mT @
                              torch.linalg.solve(cov, mean.imag).unsqueeze(1) * 1j).squeeze()
         wigner_vals = exp_real.unsqueeze(-2) * prob_g.permute(1, 0, 2) * exp_imag * self.weight.unsqueeze(-2)

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -330,6 +330,7 @@ class BosonicState(nn.Module):
         exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov, mean.imag) / 2).squeeze() # (batch, ncomb)
         if exp_real.ndim == 0: # vacuum case
             exp_real = exp_real.reshape(-1)
+        # (batch, npoints, ncomb)
         exp_imag = torch.exp((coords3 - mean.real.unsqueeze(1)).mT @
                              torch.linalg.solve(cov, mean.imag).unsqueeze(1) * 1j).squeeze()
         wigner_vals = exp_real.unsqueeze(-2) * prob_g.permute(1, 0, 2) * exp_imag * self.weight.unsqueeze(-2)

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -327,9 +327,7 @@ class BosonicState(nn.Module):
         mean = self.mean[..., idx, :]
         gauss_b = MultivariateNormal(mean.squeeze(-1).real, cov) # mean shape: (batch, ncomb, 2)
         prob_g = gauss_b.log_prob(coords2).exp() # (npoints, batch, ncomb)
-        exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov, mean.imag) / 2).squeeze() # (batch, ncomb)
-        if exp_real.ndim == 0: # vacuum case
-            exp_real = exp_real.reshape(-1)
+        exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov, mean.imag) / 2).squeeze(-2, -1) # (batch, ncomb)
         # (batch, npoints, ncomb)
         exp_imag = torch.exp((coords3 - mean.real.unsqueeze(1)).mT @
                              torch.linalg.solve(cov, mean.imag).unsqueeze(1) * 1j).squeeze()


### PR DESCRIPTION
Fix bug for `sample_homodyne_fock` function and `wigner` function
1. Ensure the non-negative `probs` in `sample_homodyne_fock` function
2. Ensure the correct dimension for `exp_real` for the vacuum state in` wigner` function