### PR TITLE
Fix bugs for Bosonic Homodyne measurement and marginal function

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1657,8 +1657,10 @@ class QumodeCircuit(Operation):
                     samples = MultivariateNormal(mean_sub.squeeze(-1), cov_sub).sample([shots])
                     samples = samples.permute(1, 0, 2)
                 elif len(self.state) == 3:
-                    weight = self.state[2]
-                    samples = sample_reject_bosonic(cov_sub, mean_sub, weight, torch.zeros_like(cov_sub), shots)
+                    cov_sub, mean_sub, weight = align_shape(cov_sub, mean_sub, self.state[2])
+                    samples = sample_reject_bosonic(cov_sub, mean_sub, weight,
+                                                    torch.zeros_like(cov_sub[0,0,:,:]),
+                                                    shots)
             return samples.squeeze()
 
     @property

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -357,7 +357,7 @@ class BosonicState(nn.Module):
         idx = torch.cat([wire, wire + self.nmode]) # xxpp order
         cov  = self.cov[..., idx[:, None], idx]
         mean = self.mean[..., idx, :]
-        r = PhaseShift(inputs=-phi, nmode=1, wires=wire.tolist(), cutoff=self.cutoff)
+        r = PhaseShift(inputs=-phi, nmode=1, wires=[0], cutoff=self.cutoff)
         r.to(cov.dtype).to(cov.device)
         cov, mean = r([cov, mean]) # (batch, ncomb, 2, 2)
         cov = cov[..., 0, 0].unsqueeze(1)


### PR DESCRIPTION
Fix bug for bosonic homodyne measurement and marginal function
1. bosonic homodyne measurement
```
cir = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=3, backend='bosonic')
cir.cat(wires=0, r=1)
state = cir()
measure_re = cir.measure_homodyne(wires=[0,1], shots=100)
print(measure_re.shape)
```
2. bosonic marginal function
```
cir = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=3, backend='bosonic')
cir.cat(wires=0, r=1)
state = cir()
s = dq.BosonicState(state, nmode=2)
qvec = torch.linspace(-5, 5, 200)
pvec = torch.linspace(-5, 5, 200)
marginal = s.marginal(wire=0, qvec=qvec, phi=0, plot=True)
```



