### PR TITLE
Fix bugs of shape and dtype for Bosonic backend

### DIFF
--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -88,12 +88,12 @@ class Generaldyne(Operation):
             weight = x[2]
             mean_m = sample_reject_bosonic(cov_b, mean_b, weight, self.cov_m, 1)[:, 0] # (batch, 2 * nwire)
             # (batch, ncomb)
-            exp_real = torch.exp(mean_b.imag.mT @ torch.linalg.solve(cov_t, mean_b.imag) / 2).squeeze()
+            exp_real = torch.exp(mean_b.imag.mT @ torch.linalg.solve(cov_t, mean_b.imag) / 2).squeeze(-2, -1)
             gaus_b = MultivariateNormal(mean_b.squeeze(-1).real, cov_t) # (batch, ncomb, 2 * nwire)
             prob_g = gaus_b.log_prob(mean_m.unsqueeze(-2)).exp() # (batch, ncomb, 2 * nwire) -> (batch, ncomb)
             rm = mean_m.unsqueeze(-1).unsqueeze(-3) # (batch, 2 * nwire) -> (batch, 1, 2 * nwire, 1)
             # (batch, ncomb)
-            exp_imag = torch.exp((rm - mean_b.real).mT @ torch.linalg.solve(cov_t, mean_b.imag) * 1j).squeeze()
+            exp_imag = torch.exp((rm - mean_b.real).mT @ torch.linalg.solve(cov_t, mean_b.imag) * 1j).squeeze(-2, -1)
             weight *= exp_real * prob_g * exp_imag
             weight /= weight.sum(dim=-1, keepdim=True)
             mean_a = mean_a + cov_ab.to(mean_b.dtype) @ torch.linalg.solve(cov_t.to(mean_b.dtype), rm - mean_b)

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -322,7 +322,7 @@ class Channel(Operation):
         mat_y = local_y.new_zeros(2 * self.nmode, 2 * self.nmode)
         mat_y[np.ix_(wires, wires)] = local_y
         cov = mat_x @ cov @ mat_x.mT + mat_y
-        mean = mat_x @ mean
+        mean = mat_x.to(mean.dtype) @ mean
         return [cov, mean] + x[2:]
 
     def forward(self, x: Union[torch.Tensor, List[torch.Tensor]]) -> Union[torch.Tensor, List[torch.Tensor]]:

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -400,7 +400,7 @@ def sample_reject_bosonic(
     count_shots = [0] * batch
     shots_tmp = shots
     mask = (weight.real > 0) | (abs(weight.imag) > 1e-8) | (abs(mean.imag) > 1e-8).any(-2).squeeze(-1)
-    exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov_m + cov, mean.imag) / 2).squeeze()
+    exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov_m + cov, mean.imag) / 2).squeeze(-2, -1)
     c_tilde = mask * abs(weight) * exp_real
     while len(batches) > 0:
         cov_rest = cov[batches]


### PR DESCRIPTION
- fix a shape error when there's no cat/gkp input state
- fix a dtype error when loss channel exits