### PR TITLE
Support simulations of distributed Fock state tensors

### DIFF
--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -41,7 +41,7 @@ from .ansatz import (
 )
 from .channel import BitFlip, PhaseFlip, Depolarizing, Pauli, AmplitudeDamping, PhaseDamping
 from .channel import GeneralizedAmplitudeDamping
-from .circuit import QubitCircuit, DistritubutedQubitCircuit
+from .circuit import QubitCircuit, DistributedQubitCircuit
 from .gate import U3Gate, PhaseShift, Identity, PauliX, PauliY, PauliZ, Hadamard
 from .gate import SGate, SDaggerGate, TGate, TDaggerGate
 from .gate import Rx, Ry, Rz, ProjectionJ, CombinedSingleGate

--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -60,3 +60,4 @@ from .photonic import permanent, takagi, hafnian, torontonian
 from .photonic import FockState, GaussianState, BosonicState, CatState, GKPState, FockStateBosonic
 from .photonic import QumodeCircuit, QumodeCircuitTDM, Clements, GaussianBosonSampling
 from .photonic import UnitaryMapper, UnitaryDecomposer, DrawClements
+from .photonic import DistributedFockState, DistributedQumodeCircuit

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -45,7 +45,7 @@ class QubitCircuit(Operation):
         mps (bool, optional): Whether to use matrix product state representation. Default: ``False``
         chi (int or None, optional): The bond dimension for matrix product state representation.
             Default: ``None``
-        shots (int, optional): The number of shots for the measurement. Default: ``1024``
+        shots (int, optional): The number of shots for the measurement. Default: 1024
 
     Raises:
         AssertionError: If the type or dimension of ``init_state`` does not match ``nqubit`` or ``den_mat``.
@@ -1307,11 +1307,19 @@ class QubitCircuit(Operation):
 
 
 class DistributedQubitCircuit(QubitCircuit):
-    def __init__(self, nqubit, name = None, reupload = False, shots = 1024):
+    """Quantum circuit for a distributed state vector.
+
+    Args:
+        nqubit (int): The number of qubits in the circuit.
+        name (str or None, optional): The name of the circuit. Default: ``None``
+        reupload (bool, optional): Whether to use data re-uploading. Default: ``False``
+        shots (int, optional): The number of shots for the measurement. Default: 1024
+    """
+    def __init__(self, nqubit, name = None, reupload = False, shots = 1024) -> None:
         super().__init__(nqubit=nqubit, init_state='zeros', name=name, den_mat=False,
                          reupload=reupload, mps=False, chi=None, shots=shots)
 
-    def set_init_state(self, init_state: Union[str, DistributedQubitState] = 'zeros'):
+    def set_init_state(self, init_state: Union[str, DistributedQubitState] = 'zeros') -> None:
         """Set the initial state of the circuit."""
         if init_state == 'zeros':
             self.init_state = DistributedQubitState(self.nqubit)
@@ -1351,7 +1359,7 @@ class DistributedQubitCircuit(QubitCircuit):
         with_prob: bool = False,
         wires: Union[int, List[int], None] = None,
         block_size: int = 2 ** 24
-    ) -> Union[Dict, List[Dict], None]:
+    ) -> Union[Dict, None]:
         """Measure the final state.
 
         Args:

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -1306,7 +1306,7 @@ class QubitCircuit(Operation):
         self.add(br)
 
 
-class DistritubutedQubitCircuit(QubitCircuit):
+class DistributedQubitCircuit(QubitCircuit):
     def __init__(self, nqubit, name = None, reupload = False, shots = 1024):
         super().__init__(nqubit=nqubit, init_state='zeros', name=name, den_mat=False,
                          reupload=reupload, mps=False, chi=None, shots=shots)
@@ -1412,7 +1412,7 @@ class DistritubutedQubitCircuit(QubitCircuit):
             dtype = self.state.amps.real.dtype
             device = self.state.amps.device
             for observable in self.observables:
-                cir_basis = DistritubutedQubitCircuit(self.nqubit)
+                cir_basis = DistributedQubitCircuit(self.nqubit)
                 for wire, basis in zip(observable.wires, observable.basis):
                     if basis == 'x':
                         cir_basis.h(wire)

--- a/src/deepquantum/communication.py
+++ b/src/deepquantum/communication.py
@@ -84,7 +84,7 @@ def comm_exchange_arrays(send_data: torch.Tensor, recv_data: torch.Tensor, pair_
     if is_valid:
         assert send_data.shape == recv_data.shape, 'Send/Recv shape must match for active P2P'
         assert send_data.dtype == recv_data.dtype, 'Send/Recv dtype must match for active P2P'
-        io_sizes[pair_rank] = send_data.numel()
+        io_sizes[pair_rank] = len(send_data)
     else:
         send_data = send_data.new_empty(0)
         recv_data = recv_data.new_empty(0)

--- a/src/deepquantum/communication.py
+++ b/src/deepquantum/communication.py
@@ -23,7 +23,7 @@ def setup_distributed(port = '29500', backend = 'nccl') -> Tuple[int, int, int]:
         world_size = 1
         local_rank = 0
         os.environ['MASTER_ADDR'] = 'localhost'
-        os.environ['MASTER_PORT'] =  port
+        os.environ['MASTER_PORT'] = port
 
     print(f'Initializing distributed setup: Rank {rank}/{world_size}, Local Rank (GPU): {local_rank}')
 

--- a/src/deepquantum/communication.py
+++ b/src/deepquantum/communication.py
@@ -40,7 +40,6 @@ def setup_distributed(port = '29500', backend = 'nccl') -> Tuple[int, int, int]:
 def cleanup_distributed() -> None:
     """Clean up the distributed environment."""
     dist.destroy_process_group()
-    print('Distributed environment cleaned up.')
 
 
 def comm_get_rank() -> int:

--- a/src/deepquantum/distributed.py
+++ b/src/deepquantum/distributed.py
@@ -278,7 +278,7 @@ def measure_dist(
                 pm_shape = wires_local + pm_shape
                 probs = probs.permute(pm_shape).reshape([2] * len(wires_local) + [-1]).sum(-1).reshape(-1)
         probs_rank = probs.new_empty(state.world_size)
-        dist.all_gather_into_tensor(probs_rank, probs.sum())
+        dist.all_gather_into_tensor(probs_rank, probs.sum().unsqueeze(0))
         blocks = torch.multinomial(probs_rank, shots, replacement=True)
         dist.broadcast(blocks, src=0)
         block_dict = Counter(blocks.cpu().numpy())

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -6,6 +6,7 @@ from . import ansatz
 from . import channel
 from . import circuit
 from . import decompose
+from . import distributed
 from . import draw
 from . import gate
 from . import hafnian_
@@ -20,7 +21,7 @@ from . import utils
 
 from .ansatz import Clements, GaussianBosonSampling, GBS_Graph
 from .channel import PhotonLoss
-from .circuit import QumodeCircuit
+from .circuit import QumodeCircuit, DistributedQumodeCircuit
 from .decompose import UnitaryDecomposer
 from .draw import DrawClements
 from .gate import PhaseShift, BeamSplitter, MZI, BeamSplitterTheta, BeamSplitterPhi, BeamSplitterSingle, UAnyGate
@@ -30,7 +31,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne, GeneralBosonic, PhotonNumberResolvingBosonic
 from .qmath import permanent, takagi, xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature
-from .state import FockState, GaussianState, BosonicState, CatState, GKPState, FockStateBosonic
+from .state import FockState, GaussianState, BosonicState, CatState, GKPState, FockStateBosonic, DistributedFockState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian
 from .utils import set_hbar, set_kappa, set_perm_chunksize

--- a/src/deepquantum/photonic/distributed.py
+++ b/src/deepquantum/photonic/distributed.py
@@ -1,0 +1,184 @@
+"""
+Distributed operations
+"""
+
+from collections import Counter
+from typing import Dict, List, Union
+
+import torch
+import torch.distributed as dist
+
+from ..communication import comm_exchange_arrays
+from ..distributed import get_local_targets
+from ..qmath import list_to_decimal, decimal_to_list, inverse_permutation, evolve_state, block_sample
+from .state import FockState, DistributedFockState
+
+
+# The 0-th mode is the rightmost for the `target`
+def get_pair_rank(rank: int, target_rank: int, new_digit: int, cutoff: int, ndigit: int) -> int:
+    """Get the pair rank for communication."""
+    digits = decimal_to_list(rank, cutoff, ndigit)
+    digits[-(target_rank+1)] = new_digit
+    return list_to_decimal(digits, cutoff)
+
+
+def get_digit(decimal: int, target: int, cutoff: int) -> int:
+    """Get the digit of a decimal number at a specific position."""
+    digits = decimal_to_list(decimal, cutoff)
+    if target >= len(digits):
+        return 0
+    else:
+        return digits[-(target+1)]
+
+
+def local_gate(state: torch.Tensor, targets: List[int], matrix: torch.Tensor) -> torch.Tensor:
+    """Apply a gate to a Fock state tensor locally."""
+    shape = state.shape
+    nmode = len(shape)
+    cutoff = shape[0]
+    wires = [nmode - target - 1 for target in targets]
+    state[:] = evolve_state(state.unsqueeze(0), matrix, nmode, wires, cutoff).squeeze(0)
+    return state
+
+
+def local_swap_gate(state: torch.Tensor, target1: int, target2: int) -> torch.Tensor:
+    """Apply a SWAP operation to a Fock state tensor locally."""
+    nmode = len(state.shape)
+    wire1 = nmode - target1 - 1
+    wire2 = nmode - target2 - 1
+    return state.transpose(wire1, wire2)
+
+
+def dist_swap_gate(state: DistributedFockState, target1: int, target2: int):
+    """Apply a SWAP operation to a distributed Fock state tensor."""
+    if target1 > target2:
+        target1, target2 = target2, target1
+    if target2 < state.nmode_local:
+        state.amps = local_swap_gate(state.amps, target1, target2)
+    elif target1 >= state.nmode_local:
+        target1_rank = target1 - state.nmode_local
+        target2_rank = target2 - state.nmode_local
+        digit1 = get_digit(state.rank, target1_rank, state.cutoff)
+        digit2 = get_digit(state.rank, target2_rank, state.cutoff)
+        if digit1 != digit2:
+            new_rank = get_pair_rank(state.rank, target1_rank, digit2, state.cutoff, state.nmode_global)
+            pair_rank = get_pair_rank(new_rank, target2_rank, digit1, state.cutoff, state.nmode_global)
+            comm_exchange_arrays(state.amps, state.buffer, pair_rank)
+            state.amps = state.buffer
+    else:
+        target2_rank = target2 - state.nmode_local
+        wire1 = state.nmode_local - target1 - 1
+        pm_shape = list(range(state.nmode_local))
+        pm_shape.remove(wire1)
+        pm_shape = [wire1] + pm_shape
+        state.amps = state.amps.permute(pm_shape).contiguous()
+        qudits = list(range(state.cutoff))
+        io_sizes = [0] * state.world_size
+        for i in qudits:
+            pair_rank = get_pair_rank(state.rank, target2_rank, i, state.cutoff, state.nmode_global)
+            io_sizes[pair_rank] = 1
+        dist.all_to_all_single(state.buffer, state.amps, io_sizes, io_sizes)
+        state.amps = state.buffer.permute(inverse_permutation(pm_shape)).contiguous()
+    return state
+
+
+def dist_gate(
+    state: DistributedFockState,
+    targets: List[int],
+    matrix: torch.Tensor
+) -> DistributedFockState:
+    """Apply a gate to a distributed Fock state tensor."""
+    nt = len(targets)
+    assert nt <= state.nmode_local
+    if max(targets) < state.nmode_local:
+        state.amps = local_gate(state.amps, targets, matrix)
+    else:
+        targets_new = get_local_targets(targets, state.nmode_local)
+        for i in range(nt):
+            if targets_new[i] != targets[i]:
+                dist_swap_gate(state, targets_new[i], targets[i])
+        state.amps = local_gate(state.amps, targets_new, matrix)
+        for i in range(nt):
+            if targets_new[i] != targets[i]:
+                dist_swap_gate(state, targets_new[i], targets[i])
+    return state
+
+
+def measure_dist(
+    state: DistributedFockState,
+    shots: int = 1024,
+    with_prob: bool = False,
+    wires: Union[int, List[int], None] = None,
+    block_size: int = 2 ** 24
+) -> Dict:
+    """Measure a distributed Fock state tensor."""
+    if isinstance(wires, int):
+        wires = [wires]
+    nwires = len(wires) if wires else state.nmode
+    probs = torch.abs(state.amps) ** 2
+    if wires is not None:
+        targets = [state.nmode - wire - 1 for wire in wires]
+        pm_shape = list(range(state.nmode_local))
+        # Assume nmode_global < nmode_local
+        if nwires <= state.nmode_local: # All targets move to local modes
+            if max(targets) >= state.nmode_local:
+                targets_new = get_local_targets(targets, state.nmode_local)
+                for i in range(nwires):
+                    if targets_new[i] != targets[i]:
+                        dist_swap_gate(state, targets_new[i], targets[i])
+                wires_local = sorted([state.nmode_local - target - 1 for target in targets_new])
+            else:
+                wires_local = sorted([state.nmode_local - target - 1 for target in targets])
+            for w in wires_local:
+                pm_shape.remove(w)
+            pm_shape = wires_local + pm_shape
+            probs = probs.permute(pm_shape).reshape([state.cutoff] * nwires + [-1]).sum(-1).reshape(-1)
+            dist.all_reduce(probs, dist.ReduceOp.SUM)
+            if state.rank == 0:
+                samples = Counter(block_sample(probs, shots, block_size))
+                results = {FockState(decimal_to_list(k, state.cutoff, nwires)): v for k, v in samples.items()}
+                if with_prob:
+                    for k in results:
+                        index = list_to_decimal(k.state, state.cutoff)
+                        results[k] = results[k], probs[index]
+                return results
+            return {}
+        else: # All targets are sorted, then move to global modes
+            targets_sort = sorted(targets, reverse=True)
+            wires_local = []
+            for i, target in enumerate(targets_sort):
+                if i < state.nmode_global:
+                    target_new = state.nmode - i - 1
+                    if target_new != target:
+                        dist_swap_gate(state, target, target_new)
+                else:
+                    wires_local.append(state.nmode_local - target - 1)
+            for w in wires_local:
+                pm_shape.remove(w)
+            pm_shape = wires_local + pm_shape
+            probs = probs.permute(pm_shape).reshape([state.cutoff] * len(wires_local) + [-1]).sum(-1)
+    probs = probs.reshape(-1)
+    probs_rank = probs.new_empty(state.world_size)
+    dist.all_gather_into_tensor(probs_rank, probs.sum())
+    blocks = torch.multinomial(probs_rank, shots, replacement=True)
+    dist.broadcast(blocks, src=0)
+    block_dict = Counter(blocks.cpu().numpy())
+    key_offset = state.rank * state.cutoff**(nwires - state.nmode_global)
+    if state.rank in block_dict:
+        samples = Counter(block_sample(probs, block_dict[state.rank], block_size))
+        results = {FockState(decimal_to_list(k + key_offset, state.cutoff, nwires)): v for k, v in samples.items()}
+    else:
+        results = {}
+    if with_prob:
+        for k in results:
+            index = list_to_decimal(k.state, state.cutoff) - key_offset
+            results[k] = results[k], probs[index]
+    results_lst = [None] * state.world_size
+    dist.all_gather_object(results_lst, results)
+    if state.rank == 0:
+        results = {}
+        for r in results_lst:
+            results.update(r)
+        return results
+    else:
+        return {}

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -15,7 +15,6 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 import deepquantum.photonic as dqp
 from ..communication import comm_get_rank, comm_get_world_size
 from ..qmath import is_power, list_to_decimal, multi_kron
-from .gate import PhaseShift
 from .qmath import dirac_ket, xpxp_to_xxpp, xxpp_to_xpxp
 
 
@@ -400,6 +399,8 @@ class BosonicState(nn.Module):
             plot (bool, optional): Whether to plot the marginal function. Default: ``True``
             k (int, optional): The marginal function of kth batch to plot. Default: 0
         """
+        # pylint: disable=import-outside-toplevel
+        from .gate import PhaseShift
         if isinstance(qrange, int):
             qlist = [-qrange, qrange]
         else:
@@ -687,7 +688,7 @@ class DistributedFockState(nn.Module):
         self.buffer.zero_()
         for s in self.state:
             amp = s[0]
-            rank = list_to_decimal(s[1][:self.nmode_global])
+            rank = list_to_decimal(s[1][:self.nmode_global], self.cutoff)
             if self.rank == rank:
                 fock_basis = tuple(s[1][self.nmode_global:])
                 self.amps[fock_basis] = amp

--- a/src/deepquantum/qmath.py
+++ b/src/deepquantum/qmath.py
@@ -64,6 +64,24 @@ def list_to_decimal(digits: List[int], base: int) -> int:
     return result
 
 
+def decimal_to_list(n: int, base: int, ndigit: Optional[int] = None) -> List[int]:
+    """Convert from decimal integer to list of digits."""
+    assert base >= 2, 'Base must be at least 2'
+    if n == 0:
+        if isinstance(ndigit, int):
+            return [0] * ndigit
+        else:
+            return [0]
+    digits = []
+    num = abs(n)
+    while num > 0:
+        num, remainder = divmod(num, base)
+        digits.insert(0, remainder)
+    if ndigit is not None:
+        digits = [0] * (ndigit - len(digits)) + digits
+    return digits
+
+
 def inverse_permutation(permute_shape: List[int]) -> List[int]:
     """Calculate the inversed permutation.
 

--- a/src/deepquantum/qmath.py
+++ b/src/deepquantum/qmath.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def is_power_of_two(n: int) -> bool:
-    """Check if an integer is power of two."""
+    """Check if an integer is a power of two."""
     def f(x):
         if x < 2:
             return False
@@ -26,6 +26,17 @@ def is_power_of_two(n: int) -> bool:
         return False
 
     return np.vectorize(f)(n)
+
+
+def is_power(n: int, base: int) -> bool:
+    """Check if an integer is a power of the given base."""
+    if n <= 0 or base <= 0 or base == 1:
+        return False
+    if n == 1:
+        return True
+    while n % base == 0:
+        n //= base
+    return n == 1
 
 
 def int_to_bitstring(x: int, n: int, debug: bool = False) -> str:
@@ -42,6 +53,15 @@ def int_to_bitstring(x: int, n: int, debug: bool = False) -> str:
             print(f'Quantum register ({n}) overflowed for {x}.')
         s = bin(x)[-n:]
     return s
+
+
+def list_to_decimal(digits: List[int], base: int) -> int:
+    """Convert from list of digits to decimal integer."""
+    result = 0
+    for digit in digits:
+        assert 0 <= digit < base, 'Invalid digit for the given base'
+        result = result * base + digit
+    return result
 
 
 def inverse_permutation(permute_shape: List[int]) -> List[int]:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -44,7 +44,7 @@ def test_fock_mps():
 
 def test_qubit_dist():
     data = torch.randn(10)
-    cir = dq.DistritubutedQubitCircuit(4, reupload=True)
+    cir = dq.DistributedQubitCircuit(4, reupload=True)
     cir.rxlayer(encode=True)
     cir.rylayer(encode=True)
     cir.rzlayer(encode=True)
@@ -53,6 +53,7 @@ def test_qubit_dist():
     cir.cnot_ring()
     cir.toffoli(0,1,2)
     cir.fredkin(2,1,0)
+    cir.swap([2,3])
     cir.rx(0, controls=[1,2,3], encode=True)
     cir.ry(1, controls=[0,2,3], encode=True)
     cir.rz(2, controls=[0,1,3], encode=True)
@@ -71,6 +72,7 @@ def test_qubit_dist():
     cir.cnot_ring()
     cir.toffoli(0,1,2)
     cir.fredkin(2,1,0)
+    cir.swap([2,3])
     cir.rx(0, controls=[1,2,3], encode=True)
     cir.ry(1, controls=[0,2,3], encode=True)
     cir.rz(2, controls=[0,1,3], encode=True)
@@ -84,7 +86,7 @@ def test_qubit_dist():
 
 def test_qubit_expectation_and_differentiation_dist():
     data1 = torch.arange(10, dtype=torch.float, requires_grad=True)
-    cir1 = dq.DistritubutedQubitCircuit(4, reupload=True)
+    cir1 = dq.DistributedQubitCircuit(4, reupload=True)
     cir1.rxlayer(encode=True)
     cir1.rylayer(encode=True)
     cir1.rzlayer(encode=True)
@@ -93,6 +95,7 @@ def test_qubit_expectation_and_differentiation_dist():
     cir1.cnot_ring()
     cir1.toffoli(0,1,2)
     cir1.fredkin(2,1,0)
+    cir1.swap([2,3])
     cir1.rx(0, controls=[1,2,3], encode=True)
     cir1.ry(1, controls=[0,2,3], encode=True)
     cir1.rz(2, controls=[0,1,3], encode=True)
@@ -117,6 +120,7 @@ def test_qubit_expectation_and_differentiation_dist():
     cir2.cnot_ring()
     cir2.toffoli(0,1,2)
     cir2.fredkin(2,1,0)
+    cir2.swap([2,3])
     cir2.rx(0, controls=[1,2,3], encode=True)
     cir2.ry(1, controls=[0,2,3], encode=True)
     cir2.rz(2, controls=[0,1,3], encode=True)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -137,3 +137,30 @@ def test_qubit_expectation_and_differentiation_dist():
 
     assert torch.allclose(exp1, exp2)
     assert torch.allclose(data1.grad, data2.grad)
+
+
+def test_qumode_dist():
+    nmode = 5
+    cutoff = 6
+    data = torch.randn(20, dtype=torch.float)
+    shots = 10000
+    key = dq.FockState([0])
+
+    cir = dq.DistributedQumodeCircuit(nmode, [0] * nmode, cutoff)
+    for i in range(nmode):
+        cir.s(i, encode=True)
+    for i in range(nmode - 1):
+        cir.bs([i, i + 1], encode=True)
+    state1 = cir(data).amps
+    rst1 = cir.measure(shots=shots, with_prob=True, wires=[0])
+
+    cir = dq.QumodeCircuit(nmode, [0] * nmode, cutoff, basis=False)
+    for i in range(nmode):
+        cir.s(i, encode=True)
+    for i in range(nmode - 1):
+        cir.bs([i, i + 1], encode=True)
+    state2 = cir(data)
+    rst2 = cir.measure(shots=shots, with_prob=True, wires=[0])
+
+    assert torch.allclose(state1, state2)
+    assert torch.allclose(rst1[key][1], rst2[key][1])

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -142,8 +142,8 @@ def test_qubit_expectation_and_differentiation_dist():
 def test_qumode_dist():
     nmode = 5
     cutoff = 6
-    data = torch.randn(20, dtype=torch.float)
     shots = 10000
+    data = torch.randn(20)
     key = dq.FockState([0])
 
     cir = dq.DistributedQumodeCircuit(nmode, [0] * nmode, cutoff)


### PR DESCRIPTION
- Add `DistributedFockState` and `DistributedQumodeCircuit`
- Support `forward` and `measure` for `DistributedQumodeCircuit`

For example:
```python
nmode = 5
cutoff = 6
shots = 10000
data = torch.randn(20)
cir = dq.DistributedQumodeCircuit(nmode, [0] * nmode, cutoff)
for i in range(nmode):
    cir.s(i, encode=True)
for i in range(nmode - 1):
    cir.bs([i, i + 1], encode=True)
state = cir(data).amps
result = cir.measure(shots=shots, with_prob=True, wires=[0])
print(state)
print(result)
```