### PR TITLE
Fix incorrect Fock probability of odd basis for mixed Gaussian states in Gaussian backend

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1090,7 +1090,7 @@ class QumodeCircuit(Operation):
             gamma_n2 = torch.repeat_interleave(gamma[nmode:], final_state)
         sub_gamma = torch.cat([gamma_n1, gamma_n2])
         if detector == 'pnrd':
-            if purity and detector == 'pnrd':
+            if purity:
                 sub_mat = sub_matrix(matrix[:nmode, :nmode], final_state, final_state)
                 half_len = len(sub_gamma) // 2
                 sub_gamma = sub_gamma[:half_len]


### PR DESCRIPTION
- Add purity check in the function `_forward_cv_prob`
- Simplify Fock basis for probability calculation with Gaussian backend
- Example:
```python
r= 0.5
nmode = 4
cir = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=2, backend='gaussian')
for i in range(nmode):
    cir.s(i, r=r)
for i in range(nmode-1):
    cir.bs([i, i+1], inputs=[np.pi/4, np.pi/5])
cov, mean = cir()
print(cov.shape, mean.shape)

idx1 = torch.tensor([0, 1, 4, 5])
cov_sub = cov[..., idx1[:, None], idx1]
mean_sub = mean[..., idx1, :]
cutoff = 5
cir_test = dq.QumodeCircuit(nmode=2, init_state='vac', cutoff=cutoff, backend='gaussian')
cir_test.state = [cov_sub, mean_sub]
cov_batch = torch.stack([cov_sub, cov_sub]).squeeze(1)
mean_batch = torch.stack([mean_sub, mean_sub]).squeeze(1)
prob1 = cir_test._forward_cv_prob(cov=cov_batch, mean=mean_batch, detector='pnrd')
# prob1 = cir_test._forward_cv_prob(cov=cov_sub, mean=mean_sub, detector='pnrd')

r= 0.5
cutoff=30
cir2 = dq.QumodeCircuit(nmode=nmode, init_state='vac', cutoff=cutoff, backend='fock', basis=False)
for i in range(nmode):
    cir2.s(i, r=r)
for i in range(nmode-1):
    cir2.bs([i, i+1], inputs=[np.pi/4, np.pi/5])
state2 = cir2()

state = [[0,0],[0,2],[2,0],[1,1],[0,4],[1,3],[2,2],[3,1],
         [0,1],[1,0],[2,1],[1,2],[3,2],[4,1],[1,4],[2,3]]
for s in state:
    p1 = prob1[dq.FockState(s, cutoff=5)]
    amp = state2[0][s[0],s[1],:,:]
    p2 = (abs(amp)**2).sum()
    print(s, 'gaussian prob:', p1, 'fock prob:', p2)

```
<img width="978" height="538" alt="image" src="https://github.com/user-attachments/assets/e3f9e842-f3ac-4c39-8691-db3ae2fefd7f" />
