### PR TITLE
Support wire cutting of QubitCircuit

### DIFF
--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -12,12 +12,14 @@ from . import bitmath
 from . import channel
 from . import circuit
 from . import communication
+from . import cutting
 from . import distributed
 from . import gate
 from . import layer
 from . import operation
 from . import optimizer
 from . import qmath
+from . import qpd
 from . import state
 from . import utils
 

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -677,7 +677,7 @@ class QubitCircuit(Operation):
         label2qpd_dict = defaultdict(list) # {label: [idx, ...]}
         gate_label_lst = []
         nbasis_lst = []
-        gate_coefficient_lst = []
+        gate_coeff_lst = []
         for label, sub_ops in label2sub_dict.items():
             for i, op in enumerate(sub_ops):
                 if isinstance(op, SingleGateQPD):
@@ -685,11 +685,11 @@ class QubitCircuit(Operation):
                     if op.label is not None and op.label not in gate_label_lst:
                         gate_label_lst.append(op.label)
                         nbasis_lst.append(len(op.bases))
-                        gate_coefficient_lst.append(op.coeffs)
+                        gate_coeff_lst.append(op.coeffs)
         indices = sorted(range(len(gate_label_lst)), key=lambda i: gate_label_lst[i])
         gate_label_lst_sorted = [gate_label_lst[i] for i in indices]
         nbasis_lst_sorted = [nbasis_lst[i] for i in indices]
-        gate_coefficient_lst_sorted = [gate_coefficient_lst[i] for i in indices]
+        gate_coeff_lst_sorted = [gate_coeff_lst[i] for i in indices]
         ranges = [range(0, nbasis) for nbasis in nbasis_lst_sorted]
         subexperiments = defaultdict(list)
         coefficients = []
@@ -727,7 +727,7 @@ class QubitCircuit(Operation):
                 subexperiments[label].append(cir)
             coeff = 1.
             for i, idx in enumerate(combination):
-                coeff *= gate_coefficient_lst_sorted[i][idx]
+                coeff *= gate_coeff_lst_sorted[i][idx]
             coefficients.append(coeff)
         return subexperiments, coefficients
 

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -1300,10 +1300,10 @@ class QubitCircuit(Operation):
         gad = GeneralizedAmplitudeDamping(inputs=inputs, nqubit=self.nqubit, wires=wires, requires_grad=requires_grad)
         self.add(gad, encode=encode)
 
-    def reset(self, wires: Union[int, List[int], None] = None) -> None:
+    def reset(self, wires: Union[int, List[int], None] = None, postselect: Optional[int] = 0) -> None:
         """Add a reset operation."""
         assert not self.den_mat and not self.mps, 'Currently NOT supported'
-        rs = Reset(nqubit=self.nqubit, wires=wires)
+        rs = Reset(nqubit=self.nqubit, wires=wires, postselect=postselect)
         self.add(rs)
 
     def barrier(self, wires: Union[int, List[int], None] = None) -> None:

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -19,7 +19,7 @@ from .distributed import measure_dist
 from .gate import ParametricSingleGate
 from .gate import U3Gate, PhaseShift, PauliX, PauliY, PauliZ, Hadamard, SGate, SDaggerGate, TGate, TDaggerGate
 from .gate import Rx, Ry, Rz, ProjectionJ, CNOT, Swap, Rxx, Ryy, Rzz, Rxy, ReconfigurableBeamSplitter, Toffoli, Fredkin
-from .gate import CombinedSingleGate, UAnyGate, LatentGate, HamiltonianGate, Reset, Barrier, WireCut
+from .gate import CombinedSingleGate, UAnyGate, LatentGate, HamiltonianGate, Reset, Barrier, WireCut, Move
 from .layer import Observable, U3Layer, XLayer, YLayer, ZLayer, HLayer, RxLayer, RyLayer, RzLayer, CnotLayer, CnotRing
 from .operation import Operation, Gate, Layer, Channel
 from .qmath import amplitude_encoding, measure, expectation, sample_sc_mcmc, sample2expval
@@ -1310,6 +1310,16 @@ class QubitCircuit(Operation):
         """Add a barrier."""
         br = Barrier(nqubit=self.nqubit, wires=wires)
         self.add(br)
+
+    def cut(self, wires: Union[int, List[int]]) -> None:
+        """Add a wire-cut operation."""
+        wc = WireCut(nqubit=self.nqubit, wires=wires)
+        self.add(wc)
+
+    def move(self, wire1: int, wire2: int, postselect: Optional[int] = 0) -> None:
+        """Add a move operation."""
+        mv = Move(nqubit=self.nqubit, wires=[wire1, wire2], postselect=postselect)
+        self.add(mv)
 
 
 class DistributedQubitCircuit(QubitCircuit):

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -677,6 +677,7 @@ class QubitCircuit(Operation):
         label2qpd_dict = defaultdict(list) # {label: [idx, ...]}
         gate_label_lst = []
         nbasis_lst = []
+        gate_coefficient_lst = []
         for label, sub_ops in label2sub_dict.items():
             for i, op in enumerate(sub_ops):
                 if isinstance(op, SingleGateQPD):
@@ -684,15 +685,16 @@ class QubitCircuit(Operation):
                     if op.label is not None and op.label not in gate_label_lst:
                         gate_label_lst.append(op.label)
                         nbasis_lst.append(len(op.bases))
+                        gate_coefficient_lst.append(op.coeffs)
         indices = sorted(range(len(gate_label_lst)), key=lambda i: gate_label_lst[i])
         gate_label_lst_sorted = [gate_label_lst[i] for i in indices]
         nbasis_lst_sorted = [nbasis_lst[i] for i in indices]
+        gate_coefficient_lst_sorted = [gate_coefficient_lst[i] for i in indices]
         ranges = [range(0, nbasis) for nbasis in nbasis_lst_sorted]
         subexperiments = defaultdict(list)
         coefficients = []
         for combination in product(*ranges):
             for label, sub_ops in label2sub_dict.items():
-                coeff = 1.
                 nqubit = sub_ops[0].nqubit
                 cir = QubitCircuit(nqubit, den_mat=self.den_mat, reupload=self.reupload, mps=self.mps, chi=self.chi,
                                    shots=self.shots)
@@ -708,7 +710,6 @@ class QubitCircuit(Operation):
                     if isinstance(op, SingleGateQPD):
                         for i, idx in enumerate(combination):
                             if op.label == gate_label_lst_sorted[i]:
-                                coeff *= op.coeffs[idx]
                                 for ops in op.bases[idx]:
                                     for gate in ops:
                                         cir.add(gate)
@@ -724,6 +725,9 @@ class QubitCircuit(Operation):
                 if observables is not None:
                     cir.observables = obs
                 subexperiments[label].append(cir)
+            coeff = 1.
+            for i, idx in enumerate(combination):
+                coeff *= gate_coefficient_lst_sorted[i][idx]
             coefficients.append(coeff)
         return subexperiments, coefficients
 

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -171,15 +171,15 @@ class QubitCircuit(Operation):
             if self.mps:
                 assert state[0].ndim in (3, 4)
                 if state[0].ndim == 3:
-                    self.state = vmap(self._forward_helper, in_dims=(0, None), randomness='different')(data, state)
+                    self.state = vmap(self._forward_helper, in_dims=(0, None))(data, state)
                 elif state[0].ndim == 4:
-                    self.state = vmap(self._forward_helper, randomness='different')(data, state)
+                    self.state = vmap(self._forward_helper)(data, state)
             else:
                 assert state.ndim in (2, 3)
                 if state.ndim == 2:
-                    self.state = vmap(self._forward_helper, in_dims=(0, None), randomness='different')(data, state)
+                    self.state = vmap(self._forward_helper, in_dims=(0, None))(data, state)
                 elif state.ndim == 3:
-                    self.state = vmap(self._forward_helper, randomness='different')(data, state)
+                    self.state = vmap(self._forward_helper)(data, state)
             self.encode(data[-1])
         return self.state
 
@@ -1302,6 +1302,7 @@ class QubitCircuit(Operation):
 
     def reset(self, wires: Union[int, List[int], None] = None) -> None:
         """Add a reset operation."""
+        assert not self.den_mat and not self.mps, 'Currently NOT supported'
         rs = Reset(nqubit=self.nqubit, wires=wires)
         self.add(rs)
 

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -676,20 +676,20 @@ class QubitCircuit(Operation):
         label2sub_dict, label2obs_dict = partition_problem(operators, qubit_labels, observables)
         label2qpd_dict = defaultdict(list) # {label: [idx, ...]}
         gate_label_lst = []
-        nbasis_lst = []
         gate_coeff_lst = []
+        nbasis_lst = []
         for label, sub_ops in label2sub_dict.items():
             for i, op in enumerate(sub_ops):
                 if isinstance(op, SingleGateQPD):
                     label2qpd_dict[label].append(i)
                     if op.label is not None and op.label not in gate_label_lst:
                         gate_label_lst.append(op.label)
-                        nbasis_lst.append(len(op.bases))
                         gate_coeff_lst.append(op.coeffs)
+                        nbasis_lst.append(len(op.bases))
         indices = sorted(range(len(gate_label_lst)), key=lambda i: gate_label_lst[i])
         gate_label_lst_sorted = [gate_label_lst[i] for i in indices]
-        nbasis_lst_sorted = [nbasis_lst[i] for i in indices]
         gate_coeff_lst_sorted = [gate_coeff_lst[i] for i in indices]
+        nbasis_lst_sorted = [nbasis_lst[i] for i in indices]
         ranges = [range(0, nbasis) for nbasis in nbasis_lst_sorted]
         subexperiments = defaultdict(list)
         coefficients = []

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -17,7 +17,7 @@ from torch import nn, vmap
 from .adjoint import AdjointExpectation
 from .channel import BitFlip, PhaseFlip, Depolarizing, Pauli, AmplitudeDamping, PhaseDamping
 from .channel import GeneralizedAmplitudeDamping
-from .cutting import transform_cut2move, partition_labels, partition_problem
+from .cutting import transform_cut2move, partition_problem
 from .distributed import measure_dist
 from .gate import ParametricSingleGate
 from .gate import U3Gate, PhaseShift, PauliX, PauliY, PauliZ, Hadamard, SGate, SDaggerGate, TGate, TDaggerGate

--- a/src/deepquantum/cutting.py
+++ b/src/deepquantum/cutting.py
@@ -1,0 +1,138 @@
+"""
+Circuit cutting
+"""
+
+from collections import defaultdict
+from collections.abc import Sequence, Hashable
+from copy import deepcopy
+from typing import Callable, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+from networkx import Graph, connected_components
+from torch import nn
+
+from .circuit import QubitCircuit
+from .gate import Barrier
+
+
+def partition_labels(
+    operators: nn.Sequential,
+    ignore: Callable = lambda x: False,
+    keep_idle_wires: bool = False
+) -> List[Optional[int]]:
+    """Generate partition labels from the connectivity of a quantum circuit."""
+    nqubit = operators[0].nqubit
+    graph = Graph()
+    graph.add_nodes_from(range(nqubit))
+    for op in operators:
+        if ignore(op):
+            continue
+        wires = op.wires + op.controls
+        for i, wire1 in enumerate(wires):
+            for wire2 in wires[i+1:]:
+                graph.add_edge(wire1, wire2)
+    qubit_subsets = list(connected_components(graph))
+    qubit_subsets.sort(key=min)
+    if not keep_idle_wires:
+        idle_wires = set(range(nqubit))
+        for op in operators:
+            wires = op.wires + op.controls
+            for wire in wires:
+                idle_wires.discard(wire)
+        qubit_subsets = [
+            subset
+            for subset in qubit_subsets
+            if not (len(subset) == 1 and next(iter(subset)) in idle_wires)
+        ]
+    qubit_labels = [None] * nqubit
+    for i, subset in enumerate(qubit_subsets):
+        for qubit in subset:
+            qubit_labels[qubit] = i
+    return qubit_labels
+
+
+def map_qubit(qubit_labels: Sequence[Hashable]) -> Tuple[List[Tuple], Dict[Hashable, List]]:
+    """Generate a qubit map given a qubit partitioning."""
+    qubit_map = []
+    label2qubits_dict = defaultdict(list)
+    for i, label in enumerate(qubit_labels):
+        if label is None:
+            qubit_map.append((None, None))
+        else:
+            qubits = label2qubits_dict[label]
+            qubit_map.append((label, len(qubits)))
+            qubits.append(i)
+    return qubit_map, dict(label2qubits_dict)
+
+
+def label_operators(operators: nn.Sequential, qubit_map: Sequence[Tuple]) -> Dict[Hashable, List]:
+    """Generate a list of operators for each partition of the circuit."""
+    unique_labels = set([label for label, _ in qubit_map if label is not None])
+    label2ops_dict = {label: [] for label in unique_labels}
+    for i, op in enumerate(operators):
+        labels = set()
+        wires = op.wires + op.controls
+        for wire in wires:
+            label = qubit_map[wire][0]
+            assert label is not None, f'The {wire}-th qubit is provided a partition label of `None`'
+            labels.add(label)
+        assert len(labels) == 1
+        label = labels.pop()
+        label2ops_dict[label].append(i)
+    return label2ops_dict
+
+
+def split_barriers(operators: nn.Sequential) -> nn.Sequential:
+    """Mutate operators to split barriers into single-qubit barriers."""
+    operators = list(operators)
+    for i, op in enumerate(operators):
+        wires = op.wires + op.controls
+        nwire = len(wires)
+        if nwire == 1 or (not type(op) is Barrier):
+            continue
+        barrier_uuid = f'Barrier_uuid={uuid4()}'
+        operators[i] = Barrier(op.nqubit, wires[0], barrier_uuid)
+        for j in range(1, nwire):
+            operators.insert(i + j, Barrier(op.nqubit, wires[j], barrier_uuid))
+    return nn.Sequential(operators)
+
+
+def combine_barriers(operators: nn.Sequential) -> nn.Sequential:
+    """Mutate operators to combine barriers with common names into a single barrier."""
+    nqubit = operators[0].nqubit
+    uuid2idx_dict = defaultdict(list)
+    for i, op in enumerate(operators):
+        if type(op) is Barrier and len(op.wires) == 1 and 'Barrier_uuid=' in op.name:
+            uuid2idx_dict[op.name].append(i)
+    cleanup_lst = []
+    for indices in uuid2idx_dict.values():
+        wires = [operators[i].wires[0] for i in indices]
+        new_barrier = Barrier(nqubit, wires)
+        operators[indices[0]] = new_barrier
+        cleanup_lst.extend(indices[1:])
+    cleanup_lst = sorted(cleanup_lst, reverse=True)
+    for i in cleanup_lst:
+        del operators[i]
+
+
+def separate_operators(operators: nn.Sequential, qubit_labels: Optional[Sequence[Hashable]] = None) -> Dict:
+    """Separate the circuit into its disconnected components."""
+    nqubit = operators[0].nqubit
+    new_ops = split_barriers(deepcopy(operators))
+    if qubit_labels is None:
+        qubit_labels = partition_labels(new_ops)
+    assert len(qubit_labels) == nqubit
+    qubit_map, label2qubits_dict = map_qubit(qubit_labels)
+    label2ops_dict = label_operators(new_ops, qubit_map)
+    label2sub_dict = {}
+    for label, indices in label2ops_dict.items():
+        sub_ops = nn.Sequential()
+        nqubit_sub = len(label2qubits_dict[label])
+        for i in indices:
+            new_ops[i].nqubit = nqubit_sub
+            wires = [qubit_map[wire][1] for wire in new_ops[i].wires]
+            new_ops[i].wires = wires
+            sub_ops.append(new_ops[i])
+        combine_barriers(sub_ops)
+        label2sub_dict[label] = sub_ops
+    return label2sub_dict

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -2779,11 +2779,12 @@ class Barrier(Gate):
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
         wires (int, List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
             Default: ``None``
+        name (str, optional): The name of the gate. Default: ``'Barrier'``
     """
-    def __init__(self, nqubit: int = 1, wires: Union[int, List[int], None] = None) -> None:
+    def __init__(self, nqubit: int = 1, wires: Union[int, List[int], None] = None, name: str = 'Barrier') -> None:
         if wires is None:
             wires = list(range(nqubit))
-        super().__init__(name='Barrier', nqubit=nqubit, wires=wires)
+        super().__init__(name=name, nqubit=nqubit, wires=wires)
         self.nancilla = 0
 
     def forward(self, x: Any) -> Any:
@@ -2801,3 +2802,14 @@ class Barrier(Gate):
         assert len(ancilla) == self.nancilla
         self.nodes = nodes
         return nn.Sequential()
+
+
+class WireCut(Barrier):
+    """Wire Cut.
+
+    Args:
+        nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
+        wires (int or List[int], optional): The indices of the qubits that the quantum operation acts on. Default: 0
+    """
+    def __init__(self, nqubit: int = 1, wires: Union[int, List[int]] = 0) -> None:
+        super().__init__(name='WireCut', nqubit=nqubit, wires=wires)

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -312,9 +312,6 @@ class ArbitraryGate(Gate):
         gate.name = name
         return gate
 
-    def _qasm(self) -> str:
-        return self._qasm_customized(self.name)
-
 
 class ParametricSingleGate(SingleGate):
     r"""A base class for single-qubit gates with parameters.
@@ -2943,9 +2940,7 @@ class Move(DoubleGate):
             return self.vector_rep(x).squeeze(0)
         return x
 
-    def _qasm(self) -> str:
-        return self._qasm_customized(self.name)
-
-    def qpd(self) -> 'MoveQPD':
+    def qpd(self, label: Optional[int] = None) -> 'MoveQPD':
+        """Get the quasiprobability-decomposition representation."""
         from .qpd import MoveQPD
-        return MoveQPD(nqubit=self.nqubit, wires=self.wires, tsr_mode=self.tsr_mode)
+        return MoveQPD(nqubit=self.nqubit, wires=self.wires, label=label, tsr_mode=self.tsr_mode)

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -4,6 +4,7 @@ Quantum gates
 
 from copy import copy
 from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
@@ -13,6 +14,10 @@ from .distributed import dist_one_targ_gate, dist_many_ctrl_one_targ_gate, dist_
 from .operation import Gate
 from .qmath import multi_kron, is_unitary, inverse_permutation, evolve_state, svd
 from .state import DistributedQubitState
+
+if TYPE_CHECKING:
+    from .qpd import MoveQPD
+
 
 class SingleGate(Gate):
     r"""A base class for single-qubit gates.
@@ -2899,7 +2904,7 @@ class WireCut(Barrier):
 
 
 class Move(DoubleGate):
-    """Move, a two-qubit operation representing a reset of the second qubit followed by a swap.
+    r"""Move, a two-qubit operation representing a reset of the second qubit followed by a swap.
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
@@ -2940,3 +2945,7 @@ class Move(DoubleGate):
 
     def _qasm(self) -> str:
         return self._qasm_customized(self.name)
+
+    def qpd(self) -> 'MoveQPD':
+        from .qpd import MoveQPD
+        return MoveQPD(nqubit=self.nqubit, wires=self.wires, tsr_mode=self.tsr_mode)

--- a/src/deepquantum/layer.py
+++ b/src/deepquantum/layer.py
@@ -19,8 +19,8 @@ class SingleLayer(Layer):
     Args:
         name (str, optional): The name of the layer. Default: ``None``
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[List[int]], List[int] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -31,7 +31,7 @@ class SingleLayer(Layer):
         self,
         name: Optional[str] = None,
         nqubit: int = 1,
-        wires: Union[int, List[List[int]], List[int], None] = None,
+        wires: Union[int, List[int], List[List[int]], None] = None,
         den_mat: bool = False,
         tsr_mode: bool = False
     ) -> None:
@@ -57,8 +57,8 @@ class ParametricSingleLayer(SingleLayer):
     Args:
         name (str or None, optional): The name of the layer. Default: ``None``
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
-            Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -122,7 +122,7 @@ class DoubleLayer(Layer):
         self,
         name: Optional[str] = None,
         nqubit: int = 2,
-        wires: Union[List[List[int]], None] = None,
+        wires: Optional[List[List[int]]] = None,
         den_mat: bool = False,
         tsr_mode: bool = False
     ) -> None:
@@ -180,8 +180,8 @@ class U3Layer(ParametricSingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         inputs (Any, optional): The parameters of the layer. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
@@ -218,8 +218,8 @@ class XLayer(SingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -244,8 +244,8 @@ class YLayer(SingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -270,8 +270,8 @@ class ZLayer(SingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -296,8 +296,8 @@ class HLayer(SingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -322,8 +322,8 @@ class RxLayer(ParametricSingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         inputs (Any, optional): The parameters of the layer. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
@@ -360,8 +360,8 @@ class RyLayer(ParametricSingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         inputs (Any, optional): The parameters of the layer. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
@@ -398,8 +398,8 @@ class RzLayer(ParametricSingleLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
-        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that the
-            quantum operation acts on. Default: ``None``
+        wires (int, List[int], List[List[int]] or None, optional): The indices of the qubits that
+            the quantum operation acts on. Default: ``None``
         inputs (Any, optional): The parameters of the layer. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
@@ -448,7 +448,7 @@ class CnotLayer(DoubleLayer):
     def __init__(
         self,
         nqubit: int = 2,
-        wires: Union[List[List[int]], None] = None,
+        wires: Optional[List[List[int]]] = None,
         name: str = 'CnotLayer',
         den_mat: bool = False,
         tsr_mode: bool = False
@@ -472,8 +472,6 @@ class CnotRing(CnotLayer):
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 2
-        wires (List[List[int]] or None, optional): The indices of the qubits that the quantum operation
-            acts on. Default: ``None``
         minmax (List[int] or None, optional): The minimum and maximum indices of qubits that the quantum
             operation acts on. Default: ``None``
         step (int, optional): The distance between the control and target qubits of each CNOT gate.

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -317,12 +317,12 @@ class Gate(Operation):
         else:
             name = 'c' * len(self.controls) + name
         # warnings.warn(f'{name} is an empty gate and should be only used to draw circuit.')
-        qasm_lst1 = [f'gate {name} ']
+        qasm_lst1 = [f'opaque {name} ']
         qasm_lst2 = [f'{name} ']
         for i, wire in enumerate(self.controls + self.wires):
             qasm_lst1.append(f'q{i},')
             qasm_lst2.append(f'q[{wire}],')
-        qasm_str1 = ''.join(qasm_lst1)[:-1] + ' { }\n'
+        qasm_str1 = ''.join(qasm_lst1)[:-1] + ';\n'
         qasm_str2 = ''.join(qasm_lst2)[:-1] + ';\n'
         if name not in Gate._qasm_new_gate:
             Gate._qasm_new_gate.append(name)
@@ -608,12 +608,12 @@ class Channel(Operation):
         """Get QASM for channels."""
         name = name.lower()
         # warnings.warn(f'{name} is an empty gate and should be only used to draw circuit.')
-        qasm_lst1 = [f'gate {name} ']
+        qasm_lst1 = [f'opaque {name} ']
         qasm_lst2 = [f'{name} ']
         for i, wire in enumerate(self.wires):
             qasm_lst1.append(f'q{i},')
             qasm_lst2.append(f'q[{wire}],')
-        qasm_str1 = ''.join(qasm_lst1)[:-1] + ' { }\n'
+        qasm_str1 = ''.join(qasm_lst1)[:-1] + ';\n'
         qasm_str2 = ''.join(qasm_lst2)[:-1] + ';\n'
         if name not in Channel._qasm_new_gate:
             Channel._qasm_new_gate.append(name)

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -1,0 +1,98 @@
+"""
+Quasiprobability decomposition gates
+"""
+
+from typing import List, Optional, Tuple
+
+from torch import nn
+
+from .gate import PauliX, Hadamard, SGate, SDaggerGate
+from .operation import GateQPD, MeasureQPD
+
+
+class DoubleGateQPD(GateQPD):
+    r"""A base class for two-qubit quasiprobability decomposition gates.
+
+    Args:
+        bases (List[Tuple[nn.Sequential, ...]]): A list of tuples describing the operations probabilistically used to
+            simulate an ideal quantum operation.
+        coeffs (List[float]): The coefficients for quasiprobability representation.
+        name (str or None, optional): The name of the quantum operation. Default: ``None``
+        nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 2
+        wires (List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
+            Default: ``None``
+        den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
+            Default: ``False`` (which means state vectors)
+        tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
+            and output are represented by a tensor of shape :math:`(\text{batch}, 2, ..., 2)`. Default: ``False``
+    """
+    def __init__(
+        self,
+        bases: List[Tuple[nn.Sequential, ...]],
+        coeffs: List[float],
+        name: Optional[str] = None,
+        nqubit: int = 2,
+        wires: Optional[List[int]] = None,
+        den_mat: bool = False,
+        tsr_mode: bool = False
+    ) -> None:
+        if wires is None:
+            wires = [0, 1]
+        assert len(wires) == 2
+        for basis in bases:
+            assert len(basis) == 2
+        super().__init__(bases=bases, coeffs=coeffs, name=name, nqubit=nqubit, wires=wires,
+                         den_mat=den_mat, tsr_mode=tsr_mode)
+
+
+class MoveQPD(DoubleGateQPD):
+    r"""QPD of the move operation.
+
+    Args:
+        nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 2
+        wires (List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
+            Default: ``None``
+        den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
+            Default: ``False`` (which means state vectors)
+        tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
+            and output are represented by a tensor of shape :math:`(\text{batch}, 2, ..., 2)`. Default: ``False``
+    """
+    def __init__(
+        self,
+        nqubit: int = 2,
+        wires: Optional[List[int]] = None,
+        den_mat: bool = False,
+        tsr_mode: bool = False
+    ) -> None:
+        if wires is None:
+            wires = [0, 1]
+        h1 = Hadamard(nqubit=nqubit, wires=wires[0], den_mat=den_mat, tsr_mode=True)
+        m1 = MeasureQPD(nqubit=nqubit, wires=wires[0])
+        sdg1 = SDaggerGate(nqubit=nqubit, wires=wires[0], den_mat=den_mat, tsr_mode=True)
+        x2 = PauliX(nqubit=nqubit, wires=wires[1], den_mat=den_mat, tsr_mode=True)
+        h2 = Hadamard(nqubit=nqubit, wires=wires[1], den_mat=den_mat, tsr_mode=True)
+        s2 = SGate(nqubit=nqubit, wires=wires[1], den_mat=den_mat, tsr_mode=True)
+
+        measure_i = nn.Sequential()
+        measure_x = nn.Sequential(h1, m1)
+        measure_y = nn.Sequential(sdg1, h1, m1)
+        measure_z = nn.Sequential(m1)
+
+        prep_0 = nn.Sequential()
+        prep_1 = nn.Sequential(x2)
+        prep_plus = nn.Sequential(h2)
+        prep_minus = nn.Sequential(x2, h2)
+        prep_iplus = nn.Sequential(h2, s2)
+        prep_iminus = nn.Sequential(x2, h2, s2)
+
+        bases = [(measure_i, prep_0),
+                (measure_i, prep_1),
+                (measure_x, prep_plus),
+                (measure_x, prep_minus),
+                (measure_y, prep_iplus),
+                (measure_y, prep_iminus),
+                (measure_z, prep_0),
+                (measure_z, prep_1)]
+        coeffs = [0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5]
+        super().__init__(bases=bases, coeffs=coeffs, name='MoveQPD', nqubit=nqubit, wires=wires,
+                         den_mat=den_mat, tsr_mode=tsr_mode)

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -1,5 +1,5 @@
 """
-Quasiprobability decomposition gates
+Quasiprobability-decomposition gates
 """
 
 from typing import List, Optional, Tuple
@@ -10,13 +10,51 @@ from .gate import PauliX, Hadamard, SGate, SDaggerGate
 from .operation import GateQPD, MeasureQPD
 
 
-class DoubleGateQPD(GateQPD):
-    r"""A base class for two-qubit quasiprobability decomposition gates.
+class SingleGateQPD(GateQPD):
+    r"""A base class for single-qubit QPD gates.
 
     Args:
         bases (List[Tuple[nn.Sequential, ...]]): A list of tuples describing the operations probabilistically used to
             simulate an ideal quantum operation.
         coeffs (List[float]): The coefficients for quasiprobability representation.
+        label (int or None, optional): The label of the gate. Default: ``None``
+        name (str or None, optional): The name of the quantum operation. Default: ``None``
+        nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 1
+        wires (List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
+            Default: ``None``
+        den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
+            Default: ``False`` (which means state vectors)
+        tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
+            and output are represented by a tensor of shape :math:`(\text{batch}, 2, ..., 2)`. Default: ``False``
+    """
+    def __init__(
+        self,
+        bases: List[Tuple[nn.Sequential, ...]],
+        coeffs: List[float],
+        label: Optional[int] = None,
+        name: Optional[str] = None,
+        nqubit: int = 1,
+        wires: Optional[List[int]] = None,
+        den_mat: bool = False,
+        tsr_mode: bool = False
+    ) -> None:
+        if wires is None:
+            wires = [0]
+        assert len(wires) == 1
+        for basis in bases:
+            assert len(basis) == 1
+        super().__init__(bases=bases, coeffs=coeffs, label=label, name=name, nqubit=nqubit, wires=wires,
+                         den_mat=den_mat, tsr_mode=tsr_mode)
+
+
+class DoubleGateQPD(GateQPD):
+    r"""A base class for two-qubit QPD gates.
+
+    Args:
+        bases (List[Tuple[nn.Sequential, ...]]): A list of tuples describing the operations probabilistically used to
+            simulate an ideal quantum operation.
+        coeffs (List[float]): The coefficients for quasiprobability representation.
+        label (int or None, optional): The label of the gate. Default: ``None``
         name (str or None, optional): The name of the quantum operation. Default: ``None``
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 2
         wires (List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
@@ -30,6 +68,7 @@ class DoubleGateQPD(GateQPD):
         self,
         bases: List[Tuple[nn.Sequential, ...]],
         coeffs: List[float],
+        label: Optional[int] = None,
         name: Optional[str] = None,
         nqubit: int = 2,
         wires: Optional[List[int]] = None,
@@ -41,17 +80,32 @@ class DoubleGateQPD(GateQPD):
         assert len(wires) == 2
         for basis in bases:
             assert len(basis) == 2
-        super().__init__(bases=bases, coeffs=coeffs, name=name, nqubit=nqubit, wires=wires,
+        super().__init__(bases=bases, coeffs=coeffs, label=label, name=name, nqubit=nqubit, wires=wires,
                          den_mat=den_mat, tsr_mode=tsr_mode)
+
+    def decompose(self) -> Tuple[SingleGateQPD, SingleGateQPD]:
+        """Decompose the gate into two single-qubit QPD gates."""
+        bases1 = []
+        bases2 = []
+        for basis in self.bases:
+            bases1.append(tuple[basis[0]])
+            bases2.append(tuple[basis[1]])
+        name = self.name + f'_label{self.label}_'
+        gate1 = SingleGateQPD(bases1, self.coeffs, self.label, name+'1', self.nqubit, self.wires[0],
+                              self.den_mat, self.tsr_mode)
+        gate2 = SingleGateQPD(bases2, self.coeffs, self.label, name+'2', self.nqubit, self.wires[1],
+                              self.den_mat, self.tsr_mode)
+        return gate1, gate2
 
 
 class MoveQPD(DoubleGateQPD):
-    r"""QPD of the move operation.
+    r"""QPD representation of the move operation.
 
     Args:
         nqubit (int, optional): The number of qubits that the quantum operation acts on. Default: 2
         wires (List[int] or None, optional): The indices of the qubits that the quantum operation acts on.
             Default: ``None``
+        label (int or None, optional): The label of the gate. Default: ``None``
         den_mat (bool, optional): Whether the quantum operation acts on density matrices or state vectors.
             Default: ``False`` (which means state vectors)
         tsr_mode (bool, optional): Whether the quantum operation is in tensor mode, which means the input
@@ -61,6 +115,7 @@ class MoveQPD(DoubleGateQPD):
         self,
         nqubit: int = 2,
         wires: Optional[List[int]] = None,
+        label: Optional[int] = None,
         den_mat: bool = False,
         tsr_mode: bool = False
     ) -> None:
@@ -86,13 +141,13 @@ class MoveQPD(DoubleGateQPD):
         prep_iminus = nn.Sequential(x2, h2, s2)
 
         bases = [(measure_i, prep_0),
-                (measure_i, prep_1),
-                (measure_x, prep_plus),
-                (measure_x, prep_minus),
-                (measure_y, prep_iplus),
-                (measure_y, prep_iminus),
-                (measure_z, prep_0),
-                (measure_z, prep_1)]
+                 (measure_i, prep_1),
+                 (measure_x, prep_plus),
+                 (measure_x, prep_minus),
+                 (measure_y, prep_iplus),
+                 (measure_y, prep_iminus),
+                 (measure_z, prep_0),
+                 (measure_z, prep_1)]
         coeffs = [0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5]
-        super().__init__(bases=bases, coeffs=coeffs, name='MoveQPD', nqubit=nqubit, wires=wires,
+        super().__init__(bases=bases, coeffs=coeffs, label=label, name='MoveQPD', nqubit=nqubit, wires=wires,
                          den_mat=den_mat, tsr_mode=tsr_mode)

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -88,12 +88,12 @@ class DoubleGateQPD(GateQPD):
         bases1 = []
         bases2 = []
         for basis in self.bases:
-            bases1.append(tuple[basis[0]])
-            bases2.append(tuple[basis[1]])
+            bases1.append(tuple([basis[0]]))
+            bases2.append(tuple([basis[1]]))
         name = self.name + f'_label{self.label}_'
-        gate1 = SingleGateQPD(bases1, self.coeffs, self.label, name+'1', self.nqubit, self.wires[0],
+        gate1 = SingleGateQPD(bases1, self.coeffs, self.label, name+'1', self.nqubit, [self.wires[0]],
                               self.den_mat, self.tsr_mode)
-        gate2 = SingleGateQPD(bases2, self.coeffs, self.label, name+'2', self.nqubit, self.wires[1],
+        gate2 = SingleGateQPD(bases2, self.coeffs, self.label, name+'2', self.nqubit, [self.wires[1]],
                               self.den_mat, self.tsr_mode)
         return gate1, gate2
 


### PR DESCRIPTION
```python
cir = dq.QubitCircuit(7)
for i in range(7):
    cir.rx(i, np.pi / 4)
cir.cut(6)
cir.cx(0, 3)
cir.cx(1, 3)
cir.cx(2, 3)
cir.cut(3)
cir.cx(3, 4)
cir.cx(3, 5)
cir.cx(3, 6)
cir.cut(3)
cir.cx(0, 3)
cir.cx(1, 3)
cir.cx(2, 3)
cir.observable(6)
cir.observable(3)
cir.observable(0)

subexperiments, coefficients = cir.get_subexperiments()

shots = 1024
expval_total = 0
for i, coeff in enumerate(coefficients):
    expval = torch.ones(3) * coeff
    for label, subcircuits in subexperiments.items():
        subcircuits[i]()
        expval_per_label = subcircuits[i].expectation(shots=shots)
        expval *= expval_per_label
    expval_total += expval
reconstructed_expval = expval_total.sum()
```