### PR TITLE
Optimize 'get_unitary' for QumodeCircuit

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -773,12 +773,16 @@ class QumodeCircuit(Operation):
                     u = op.gate.get_unitary()
                 else:
                     u = torch.block_diag(u, torch.eye(1, dtype=u.dtype, device=u.device))
-                    u = op.gate.get_unitary() @ u
+                    u_local = op.gate.update_matrix()
+                    u_update = u[np.ix_(op.gate.wires, list(range(op.gate.nmode)))]
+                    u[np.ix_(op.gate.wires, list(range(op.gate.nmode)))] = u_local @ u_update
             else:
                 if u is None:
                     u = op.get_unitary()
                 else:
-                    u = torch.block_diag(op.get_unitary(), torch.eye(nloss, dtype=u.dtype, device=u.device)) @ u
+                    u_local = op.update_matrix()
+                    u_update = u[np.ix_(op.wires, list(range(op.nmode + nloss)))]
+                    u[np.ix_(op.wires, list(range(op.nmode + nloss)))] = u_local @ u_update
         if u is None:
             return torch.eye(self.nmode, dtype=torch.cfloat)
         else:


### PR DESCRIPTION
- Using local matrix multiplication to compute the global unitary matrix significantly improves computational efficiency and reduces the memory usage of the computational graph. For instance, this approach achieves a 10× speedup for a 200-mode Clements circuit at double precision.
<img width="722" height="364" alt="截屏2025-11-20 17 47 49" src="https://github.com/user-attachments/assets/2890c566-3039-4da3-9a5e-7da1cebc5ee0" />
