### PR TITLE
Fix the post-processing of chain-rule sampling on specific wires for Gaussian backend (#120)

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1415,6 +1415,7 @@ class QumodeCircuit(Operation):
 
         See https://arxiv.org/pdf/2108.01622
         """
+        assert not self._if_delayloop, 'Currently Fock measurement is not supported with delay loops'
         cov, mean = self.state
         batch = cov.shape[0]
         all_results = []
@@ -1444,8 +1445,7 @@ class QumodeCircuit(Operation):
                     if mcmc:
                         prob = self._get_prob_gaussian(k, [cov[i], mean[i]])
                     else:
-                        wires_ = sorted(self._convert_indices(wires))
-                        wires_ = torch.tensor(wires_, device=cov.device)
+                        wires_ = torch.tensor(wires, device=cov.device)
                         idx = torch.cat([wires_, wires_ + self.nmode])
                         prob = self._get_prob_gaussian(k, [cov[i][idx[:, None], idx], mean[i][idx, :]])
                     samples_i[k] = samples_i[k], prob


### PR DESCRIPTION
- Description:  
  Bug for chain-rule sampling on specific wires #120.
<img width="537" height="605" alt="image" src="https://github.com/user-attachments/assets/695c7329-8d23-4608-a053-59e14a080faa" />

- Root Cause:
The implementation reused the same post-processing method as in the MCMC case. However, the sample structures of the two methods are different.
<img width="599" height="367" alt="image" src="https://github.com/user-attachments/assets/4ad34932-edd2-4ca1-97e3-584597dd36ca" />
<img width="656" height="441" alt="image" src="https://github.com/user-attachments/assets/0e069a3a-db0c-401d-8f77-08814aed68cf" />

- Solution: 
Adding an additional post-process method for the chain-rule case.

