### PR TITLE
Fix numerical instability in higher-order gradients of Hafnian (#133)

### DIFF
--- a/src/deepquantum/photonic/hafnian_.py
+++ b/src/deepquantum/photonic/hafnian_.py
@@ -51,30 +51,31 @@ def get_submat_haf(a: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
     submat = a[idx][:, idx]
     return submat
 
-def trace_powers(a, power):
-    """
-    Compute [Tr(a^0), Tr(a^1), ..., Tr(a^power)] in one forward pass.
-    Autograd & Hessian safe.
-    """
-    traces = []
-    x = torch.diag(a.new_ones(a.shape[0]))
-    traces.append(torch.trace(x)) # a^0
-    for _ in range(power):
-        x = x @ a
-        traces.append(torch.trace(x))
-    return torch.stack(traces)
-
 def poly_lambda(submat: torch.Tensor, int_partition: List, power: int, loop: bool = False) -> torch.Tensor:
     """Get the coefficient of the polynomial."""
     size = submat.shape[-1]
     identity = torch.eye(size, dtype=submat.dtype, device=submat.device)
     x_mat = identity.reshape(size // 2, 2, size).flip(1).reshape(size, size)
     xaz = x_mat @ submat
-    trace_list = trace_powers(xaz, power)
+    # trace power calculation
+    traces = []
+    x = xaz.new_ones(xaz.shape[-1]).diag()
+    traces.append(torch.trace(x))
+    for _ in range(power):
+        x = x @ xaz
+        traces.append(torch.trace(x))
+    trace_list = torch.stack(traces)
     coeff = 0
     if loop: # loop hafnian case
         v = torch.diag(submat)
-        diag_term = torch.stack([v @ torch.linalg.matrix_power(xaz, i - 1) @ x_mat @ v / 2 for i in range(1, power+1)])
+        # matrix power calculation
+        diag_term = []
+        x = xaz.new_ones(xaz.shape[-1]).diag()
+        diag_term.append(v @ x @ x_mat @ v / 2)
+        for _ in range(power):
+            x = x @ xaz
+            diag_term.append(v @ x @ x_mat @ v / 2)
+        diag_term = torch.stack(diag_term)
     for orders in int_partition:
         ncount = count_unique_permutations(orders)
         orders = torch.tensor(orders, device=submat.device)

--- a/src/deepquantum/photonic/hafnian_.py
+++ b/src/deepquantum/photonic/hafnian_.py
@@ -55,8 +55,8 @@ def get_submat_haf(a: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
 def poly_lambda(submat: torch.Tensor, int_partition: List, power: int, loop: bool = False) -> torch.Tensor:
     """Get the coefficient of the polynomial.
 
-    See https://arxiv.org/abs/1805.12498 Eq.(3.26) with typo and
-    https://research-information.bris.ac.uk/ws/portalfiles/portal/329011096/thesis.pdf Eq.(3.30)
+    See https://arxiv.org/abs/1805.12498 Eq.(3.26) (noting that Eq.(3.26) contains a typo) and
+    https://research-information.bris.ac.uk/ws/portalfiles/portal/329011096/thesis.pdf Eq.(3.80)
     """
     size = submat.shape[-1]
     identity = torch.eye(size, dtype=submat.dtype, device=submat.device)

--- a/src/deepquantum/photonic/hafnian_.py
+++ b/src/deepquantum/photonic/hafnian_.py
@@ -56,9 +56,8 @@ def trace_powers(a, power):
     Compute [Tr(a^0), Tr(a^1), ..., Tr(a^power)] in one forward pass.
     Autograd & Hessian safe.
     """
-    n = a.shape[0]
     traces = []
-    x = torch.diag(a.new_ones(a.size()[0]))
+    x = torch.diag(a.new_ones(a.shape[0]))
     traces.append(torch.trace(x)) # a^0
     for _ in range(power):
         x = x @ a

--- a/src/deepquantum/photonic/hafnian_.py
+++ b/src/deepquantum/photonic/hafnian_.py
@@ -59,6 +59,7 @@ def poly_lambda(submat: torch.Tensor, int_partition: List, power: int, loop: boo
     x_mat = identity.reshape(size // 2, 2, size).flip(1).reshape(size, size)
     xaz = x_mat @ submat
     eigen = torch.linalg.eigvals(xaz) # eigen decomposition
+    # trace_list = torch.stack([torch.trace(torch.matrix_power(xaz, i)) for i in range(0, power + 1)])
     trace_list = torch.stack([(eigen ** i).sum() for i in range(0, power + 1)])
     coeff = 0
     if loop: # loop hafnian case


### PR DESCRIPTION
- Root cause
The numerical instability comes from the trace power calculation in function ``poly_lambda``, where ``torch.eigen`` is used.
When the matrix has degenerate or nearly degenerate eigenvalues, the backward pass involves divisions by small eigenvalue gaps, which leads to ``NaN`` results in the Hessian computation.
- Solution
 We replace the eigenvalue-based trace power computation with an iterative approach. A new function ``trace_powers`` is introduced. A simple case is as follows,
<img width="1176" height="1191" alt="image" src="https://github.com/user-attachments/assets/739a37ee-2874-444d-abd0-fca87070bcc0" />

- Simple benchmark
The benchmark results (hafnian) are shown as follows,
<img width="971" height="610" alt="image" src="https://github.com/user-attachments/assets/8011ce20-d572-4ff5-bc6b-c48fc8a6053d" />

-- blue curve: the new iterative implementation ``trace_powers``
-- orange curve: Pytorch built-in ``torch.matrix_power``
-- green curve: the original eigenvalue decomposition–based approach

The benchmark results  for the photon loss case with displacement (loop hafnian),
<img width="1315" height="820" alt="image" src="https://github.com/user-attachments/assets/de05629e-84b0-45c8-ae0f-0ee71a338d33" />

The benchmark results  for hafnian calculation for matrix sizes 4, 12, and 20

<img width="1417" height="455" alt="image" src="https://github.com/user-attachments/assets/db8a3c0b-4157-4fe4-9a96-eca17ec2b9bf" />


