### PR TITLE
Wigner function implementation from Fock state tensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = ['pytest',
        'perceval-quandela',
+       'qutip',
        'strawberryfields',
        'thewalrus',
        'graphix==0.3.1']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest
 perceval-quandela
+qutip
 strawberryfields @ git+https://github.com/XanaduAI/strawberryfields.git@master
 thewalrus @ git+https://github.com/XanaduAI/thewalrus.git@master
 graphix==0.3.1

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -31,7 +31,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne, GeneralBosonic, PhotonNumberResolvingBosonic
 from .qmath import permanent, takagi, sqrtm_herm, schur_anti_symm_even, williamson
-from .qmath import xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature, fock_wigner
+from .qmath import xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature, fock_to_wigner, cv_to_wigner
 from .state import FockState, GaussianState, BosonicState, CatState, GKPState, FockStateBosonic, DistributedFockState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian

--- a/src/deepquantum/photonic/__init__.py
+++ b/src/deepquantum/photonic/__init__.py
@@ -31,7 +31,7 @@ from .hafnian_ import hafnian
 from .mapper import UnitaryMapper
 from .measurement import Generaldyne, Homodyne, GeneralBosonic, PhotonNumberResolvingBosonic
 from .qmath import permanent, takagi, sqrtm_herm, schur_anti_symm_even, williamson
-from .qmath import xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature
+from .qmath import xxpp_to_xpxp, xpxp_to_xxpp, quadrature_to_ladder, ladder_to_quadrature, fock_wigner
 from .state import FockState, GaussianState, BosonicState, CatState, GKPState, FockStateBosonic, DistributedFockState
 from .tdm import QumodeCircuitTDM
 from .torontonian_ import torontonian

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -659,8 +659,8 @@ def fock_to_wigner(
             w_list[j] = temp2
             w += 2 * (reduced_dm[:, i, j].reshape(-1, 1, 1) * w_list[j]).real
     if plot:
-        plot_wigner(w, xvec, pvec, k=k)
-    return w
+        plot_wigner(w.real, xvec, pvec, k=k)
+    return w.real
 
 
 def cv_to_wigner(
@@ -747,7 +747,7 @@ def plot_wigner(
     wigner: torch.Tensor,
     xvec: torch.Tensor,
     pvec: torch.Tensor,
-    k: int=0
+    k: int = 0
 ):
     """Plot a 2D contour and a 3D surface of a discretized Wigner function W(x, p).
 
@@ -762,10 +762,10 @@ def plot_wigner(
     ax1 = plt.subplot(121)
     plt.xlabel('Quadrature q')
     plt.ylabel('Quadrature p')
-    plt.contourf(grid_x.cpu(), grid_y.cpu(), wigner[k].real.cpu(), 60, cmap=cm.RdBu)
+    plt.contourf(grid_x.cpu(), grid_y.cpu(), wigner[k].cpu(), 60, cmap=cm.RdBu)
     plt.colorbar(shrink=0.5)
     ax2 = plt.subplot(122, projection='3d')
-    surf = ax2.plot_surface(grid_x.cpu(), grid_y.cpu(), wigner[k].real.cpu(), cmap=cm.RdBu, alpha=0.8)
+    surf = ax2.plot_surface(grid_x.cpu(), grid_y.cpu(), wigner[k].cpu(), cmap=cm.RdBu, alpha=0.8)
     ax2.set_xlabel('Quadrature q')
     ax2.set_ylabel('Quadrature p')
     ax2.set_zlabel('W(q,p)')

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -239,9 +239,9 @@ def quadrature_to_ladder(tensor: torch.Tensor, symplectic: bool = False) -> torc
         if symplectic:
             return omega @ tensor @ omega.mH / 2 # inversed omega
         else:
-            return omega @ tensor @ omega.mH * dqp.kappa**2 / dqp.hbar
+            return omega @ tensor @ omega.mH * dqp.kappa ** 2 / dqp.hbar
     elif tensor.shape[-1] == 1:
-        return omega @ tensor * dqp.kappa / dqp.hbar**0.5
+        return omega @ tensor * dqp.kappa / dqp.hbar ** 0.5
 
 
 def ladder_to_quadrature(tensor: torch.Tensor, symplectic: bool = False) -> torch.Tensor:
@@ -261,9 +261,9 @@ def ladder_to_quadrature(tensor: torch.Tensor, symplectic: bool = False) -> torc
         if symplectic:
             return (omega @ tensor @ omega.mH).real / 2 # inversed omega
         else:
-            return (omega @ tensor @ omega.mH).real * dqp.hbar / (4 * dqp.kappa**2)
+            return (omega @ tensor @ omega.mH).real * dqp.hbar / (4 * dqp.kappa ** 2)
     elif tensor.shape[-1] == 1:
-        return (omega @ tensor).real * dqp.hbar**0.5 / (2 * dqp.kappa)
+        return (omega @ tensor).real * dqp.hbar ** 0.5 / (2 * dqp.kappa)
 
 
 def _photon_number_mean_var_gaussian(cov: torch.Tensor, mean: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -272,7 +272,7 @@ def _photon_number_mean_var_gaussian(cov: torch.Tensor, mean: torch.Tensor) -> T
     cov = cov.reshape(-1, 2, 2)
     mean = mean.reshape(-1, 2, 1)
     exp = coef * (vmap(torch.trace)(cov) + (mean.mT @ mean).squeeze()) - 1 / 2
-    var = coef**2 * (vmap(torch.trace)(cov @ cov) + 2 * (mean.mT @ cov.to(mean.dtype) @ mean).squeeze()) * 2 - 1 / 4
+    var = coef ** 2 * (vmap(torch.trace)(cov @ cov) + 2 * (mean.mT @ cov.to(mean.dtype) @ mean).squeeze()) * 2 - 1 / 4
     return exp, var
 
 
@@ -290,7 +290,7 @@ def _photon_number_mean_var_bosonic(
     exp_gaussian = exp_gaussian.reshape(shape_cov[:2])
     var_gaussian = var_gaussian.reshape(shape_cov[:2])
     exp = (weight * exp_gaussian).sum(-1)
-    var = (weight * var_gaussian).sum(-1) + (weight * exp_gaussian**2).sum(-1) - exp ** 2
+    var = (weight * var_gaussian).sum(-1) + (weight * exp_gaussian ** 2).sum(-1) - exp ** 2
     zeros = cov.new_zeros(1)
     assert torch.allclose(exp.imag, zeros, atol=1e-6)
     assert torch.allclose(var.imag, zeros, atol=1e-6)
@@ -473,7 +473,7 @@ def sample_homodyne_fock(
     nbin: int = 100000
 ) -> torch.Tensor:
     """Get the samples of homodyne measurement for batched Fock state tensors on one mode."""
-    coef = 2 * dqp.kappa**2 / dqp.hbar
+    coef = 2 * dqp.kappa ** 2 / dqp.hbar
     if den_mat:
         state = state.reshape(-1, cutoff ** nmode, cutoff ** nmode)
     else:
@@ -484,12 +484,12 @@ def sample_homodyne_fock(
     orders = torch.arange(cutoff, dtype=state.real.dtype, device=state.device).reshape(-1, 1) # (cutoff, 1)
     # with dimension \sqrt{m\omega\hbar}
     xs = torch.linspace(-x_range, x_range, nbin, dtype=state.real.dtype, device=state.device) # (nbin)
-    h_vals = torch.special.hermite_polynomial_h(coef**0.5 * xs, orders) #（cutoff, nbin)
+    h_vals = torch.special.hermite_polynomial_h(coef ** 0.5 * xs, orders) #（cutoff, nbin)
     # H_n / \sqrt{2^n * n!}
-    h_vals = h_vals / torch.sqrt(2**orders * torch.exp(torch.lgamma(orders.double() + 1))).to(orders.dtype)
+    h_vals = h_vals / torch.sqrt(2 ** orders * torch.exp(torch.lgamma(orders.double() + 1))).to(orders.dtype)
     h_mat = h_vals.reshape(1, cutoff, nbin) * h_vals.reshape(cutoff, 1, nbin) # (cutoff, cutoff, nbin)
     h_terms = reduced_dm.unsqueeze(-1) * h_mat # (batch, cutoff, cutoff, nbin)
-    probs = (h_terms.sum(dim=[-3, -2]) * torch.exp(-coef * xs**2)).real # (batch, nbin)
+    probs = (h_terms.sum(dim=[-3, -2]) * torch.exp(-coef * xs ** 2)).real # (batch, nbin)
     probs = abs(probs)
     probs[probs < 1e-10] = 0
     indices = torch.multinomial(probs.reshape(-1, nbin), num_samples=shots, replacement=True) # (batch, shots)
@@ -574,6 +574,7 @@ def align_shape(cov: torch.Tensor, mean: torch.Tensor, weight: torch.Tensor) -> 
             mean = mean.expand(ncomb, -1, -1)
     return [cov, mean, weight]
 
+
 def fock_to_wigner(
     state: torch.Tensor,
     wire: int,
@@ -582,29 +583,32 @@ def fock_to_wigner(
     den_mat: bool = False,
     xrange: Union[int, List] = 10,
     prange: Union[int, List] = 10,
-    npoints: Union[int, List] = 200,
+    npoints: Union[int, List] = 100,
     plot: bool = True,
     k: int = 0
 ) -> torch.Tensor:
-    """Compute the Wigner function W(q, p) from a Fock tensor state or density matrix
+    """Compute the Wigner function W(q, p) from a Fock state tensor or density matrix
     using the iterative method.
 
     See https://qutip.org/docs/4.7/modules/qutip/wigner.html
 
     Args:
-        state(List): The input Fock state tensor or density matrix.
+        state (List): The input Fock state tensor or density matrix.
         wire (int): The wigner function for given wire.
-        nmode(int): The mode number of the Fock state.
+        nmode (int): The mode number of the Fock state.
+        cutoff (int): The Fock space truncation.
+        den_mat (bool, optional): Whether to use density matrix representation. Only valid for Fock state tensor.
+            Default: ``False``
         xrange (int or List, optional): The range of quadrature q. Default: 10
         prange (int or List, optional): The range of quadrature p. Default: 10
-        npoints(int or List, optional): The number of discretization points for quadratures. Default: 200
+        npoints (int or List, optional): The number of discretization points for quadratures. Default: 100
         plot (bool, optional): Whether to plot the wigner function. Default: ``True``
-        k (int, optional): The wigner function of kth batch to plot. Default: 0
+        k (int, optional): The index of the Wigner function within the batch to plot. Default: 0
     """
     if den_mat:
-        rho = state.reshape(-1, cutoff**nmode, cutoff**nmode)
+        rho = state.reshape(-1, cutoff ** nmode, cutoff ** nmode)
     else:
-        state = state.reshape(-1, cutoff**nmode, 1)
+        state = state.reshape(-1, cutoff ** nmode, 1)
         rho = state @ state.mH
     trace_lst = [i for i in range(nmode) if i != wire]
     reduced_dm = partial_trace(rho, nmode, trace_lst, cutoff) # (batch, cutoff, cutoff)
@@ -628,57 +632,56 @@ def fock_to_wigner(
     xvec = torch.linspace(*xlist, dtype=torch.double)
     pvec = torch.linspace(*plist, dtype=torch.double)
     coef = 2 * dqp.kappa ** 2 / dqp.hbar
-    xvec = coef ** 0.5 * xvec
-    pvec = coef ** 0.5 * pvec
     xlist, plist = torch.meshgrid(xvec, pvec, indexing='ij')
-    # alpha = (q + i p) / sqrt(2)
-    alpha = (xlist + 1.0j * plist) / rho.new_tensor(2.0).sqrt()
+    # alpha = (sqrt(2) * kappa / sqrt(hbar)) * (q + i p) / sqrt(2)
+    alpha = coef ** 0.5 * (xlist + 1.0j * plist) / 2 ** 0.5
     w_list = xlist.new_zeros(cutoff, xlist.shape[-2], xlist.shape[-1]) * 1j
-    w_00 = coef * torch.exp(-2 * abs(alpha)**2) / torch.pi
+    w_00 = coef * torch.exp(-2 * abs(alpha) ** 2) / torch.pi
     w_list[0] = w_00
-    w  = reduced_dm[:,0,0].reshape(-1,1,1) * w_list[0]
+    w = reduced_dm[:, 0, 0].reshape(-1, 1, 1) * w_list[0]
     # First row: W_{0i}
     for i in range(1, cutoff):
         # For numerical stability, it is recommended to use cutoff < 80
         w_list[i] = 2 * alpha * w_list[i-1] / rho.new_tensor(i).sqrt()
-        w += 2 * (reduced_dm[:,0,i].reshape(-1,1,1) * w_list[i]).real
+        w += 2 * (reduced_dm[:, 0, i].reshape(-1, 1, 1) * w_list[i]).real
     # Remaining rows: W_{ij}, i ≥ 1
     for i in range(1, cutoff):
         # Diagonal element W_{ii}
-        sqrt_i = rho.new_tensor(i).sqrt()
+        sqrt_i = i ** 0.5
         temp = w_list[i].clone()
         w_list[i] = (2 * alpha.conj() * temp - sqrt_i * w_list[i-1]) / sqrt_i
-        w += reduced_dm[:,i,i].reshape(-1,1,1) * w_list[i]
+        w += reduced_dm[:, i, i].reshape(-1, 1, 1) * w_list[i]
         # Off-diagonal elements W_{ij}, j > i
         for j in range(i+1, cutoff):
-            sqrt_j = rho.new_tensor(j).sqrt()
+            sqrt_j = j ** 0.5
             temp2 = (2 * alpha * w_list[j-1] - sqrt_i * temp) / sqrt_j
             temp = w_list[j].clone()
             w_list[j] = temp2
-            w += 2 * (reduced_dm[:,i,j].reshape(-1,1,1) * w_list[j]).real
+            w += 2 * (reduced_dm[:, i, j].reshape(-1, 1, 1) * w_list[j]).real
     if plot:
         plot_wigner(w, xvec, pvec, k=k)
     return w
+
 
 def cv_to_wigner(
     state: List,
     wire: int,
     xrange: Union[int, List] = 10,
     prange: Union[int, List] = 10,
-    npoints: Union[int, List] = 200,
+    npoints: Union[int, List] = 100,
     plot: bool = True,
     k: int = 0
 ):
     """Get the discretized Wigner function of the specified mode.
 
     Args:
-        state(List): The input Gaussianstate or BosonicState.
+        state (List): The input Gaussianstate or BosonicState.
         wire (int): The wigner function for given wire.
         xrange (int or List, optional): The range of quadrature q. Default: 10
         prange (int or List, optional): The range of quadrature p. Default: 10
-        npoints(int or List, optional): The number of discretization points for quadratures. Default: 200
+        npoints (int or List, optional): The number of discretization points for quadratures. Default: 100
         plot (bool, optional): Whether to plot the wigner function. Default: ``True``
-        k (int, optional): The wigner function of kth batch to plot. Default: 0
+        k (int, optional): The index of the Wigner function within the batch to plot. Default: 0
     """
     if isinstance(xrange, int):
         xlist = [-xrange, xrange]
@@ -727,7 +730,7 @@ def cv_to_wigner(
     exp_real = torch.exp(mean.imag.mT @ torch.linalg.solve(cov, mean.imag) / 2).squeeze(-2, -1) # (batch, ncomb)
     # (batch, npoints, ncomb)
     exp_imag = torch.exp((coords3 - mean.real.unsqueeze(1)).mT @
-                            torch.linalg.solve(cov, mean.imag).unsqueeze(1) * 1j).squeeze(-2, -1)
+                         torch.linalg.solve(cov, mean.imag).unsqueeze(1) * 1j).squeeze(-2, -1)
     wigner_vals = exp_real.unsqueeze(-2) * prob_g.permute(1, 0, 2) * exp_imag * weight.unsqueeze(-2)
     wigner_vals = wigner_vals.sum(dim=2).reshape(-1, len(xvec), len(pvec)).real
     # normalize the wigner function
@@ -738,6 +741,7 @@ def cv_to_wigner(
     if plot:
         plot_wigner(wigner_vals, xvec, pvec, k=k)
     return wigner_vals
+
 
 def plot_wigner(
     wigner: torch.Tensor,
@@ -751,17 +755,17 @@ def plot_wigner(
         wigner (torch.Tensor): Discretized Wigner values with shape (batch, len(xvec), len(pvec)).
         xvec (torch.Tensor): 1D grid for quadrature q.
         pvec (torch.Tensor): 1D grid for quadrature p.
-        k (int, optional): Batch index to plot. Default: 0.
+        k (int, optional): The index of the Wigner function within the batch to plot. Default: 0
     """
     grid_x, grid_y = torch.meshgrid(xvec, pvec, indexing='ij')
     fig, axes = plt.subplots(1, 2, figsize=(16, 8))
     ax1 = plt.subplot(121)
     plt.xlabel('Quadrature q')
     plt.ylabel('Quadrature p')
-    plt.contourf(grid_x.cpu(), grid_y.cpu(), wigner[k].cpu(), 60, cmap=cm.RdBu)
+    plt.contourf(grid_x.cpu(), grid_y.cpu(), wigner[k].real.cpu(), 60, cmap=cm.RdBu)
     plt.colorbar(shrink=0.5)
     ax2 = plt.subplot(122, projection='3d')
-    surf = ax2.plot_surface(grid_x.cpu(), grid_y.cpu(), wigner[k].cpu(), cmap=cm.RdBu, alpha=0.8)
+    surf = ax2.plot_surface(grid_x.cpu(), grid_y.cpu(), wigner[k].real.cpu(), cmap=cm.RdBu, alpha=0.8)
     ax2.set_xlabel('Quadrature q')
     ax2.set_ylabel('Quadrature p')
     ax2.set_zlabel('W(q,p)')

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -607,6 +607,7 @@ def fock_wigner(
     w  = rho[:,0,0].reshape(-1,1,1) * w_list[0]
     # First row: W_{0i}
     for i in range(1, cutoff):
+        # For numerical stability, it is recommended to use cutoff < 80
         w_list[i] = 2 * alpha * w_list[i-1] / rho.new_tensor(i).sqrt()
         w += 2 * (rho[:,0,i].reshape(-1,1,1) * w_list[i]).real
     # Remaining rows: W_{ij}, i ≥ 1

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 from scipy.special import comb
 from torch import nn, vmap
-from torch.distributions.multivariate_normal import MultivariateNormal
 
 import deepquantum.photonic as dqp
 from ..communication import comm_get_rank, comm_get_world_size
@@ -125,6 +124,7 @@ class FockState(nn.Module):
         else:
             self.state = self.state.to(arg)
         return self
+
     def wigner(
         self,
         wire: int,

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -140,7 +140,7 @@ class FockState(nn.Module):
             wire (int): The wigner function for given wire.
             xrange (int or List, optional): The range of quadrature q. Default: 10
             prange (int or List, optional): The range of quadrature p. Default: 10
-            npoints(int or List, optional): The number of discretization points for quadratures. Default: 200
+            npoints (int or List, optional): The number of discretization points for quadratures. Default: 100
             plot (bool, optional): Whether to plot the wigner function. Default: ``True``
             k (int, optional): The wigner function of kth batch to plot. Default: 0
         """
@@ -261,7 +261,7 @@ class GaussianState(nn.Module):
             wire (int): The wigner function for given wire.
             xrange (int or List, optional): The range of quadrature q. Default: 10
             prange (int or List, optional): The range of quadrature p. Default: 10
-            npoints(int or List, optional): The number of discretization points for quadratures. Default: 200
+            npoints (int or List, optional): The number of discretization points for quadratures. Default: 100
             plot (bool, optional): Whether to plot the wigner function. Default: ``True``
             k (int, optional): The wigner function of kth batch to plot. Default: 0
         """
@@ -366,7 +366,7 @@ class BosonicState(nn.Module):
             wire (int): The wigner function for given wire.
             xrange (int or List, optional): The range of quadrature q. Default: 10
             prange (int or List, optional): The range of quadrature p. Default: 10
-            npoints(int or List, optional): The number of discretization points for quadratures. Default: 200
+            npoints (int or List, optional): The number of discretization points for quadratures. Default: 100
             plot (bool, optional): Whether to plot the wigner function. Default: ``True``
             k (int, optional): The wigner function of kth batch to plot. Default: 0
         """
@@ -377,7 +377,7 @@ class BosonicState(nn.Module):
         wire: int,
         phi: float = 0.,
         xrange: Union[int, List] = 10,
-        npoints: int = 200,
+        npoints: int = 100,
         plot: bool = True,
         k: int = 0
     ):
@@ -387,9 +387,9 @@ class BosonicState(nn.Module):
             wire (int): The marginal function for given wire.
             phi (float, optional): The angle used to compute the linear combination of quadratures. Default: 0
             xrange (int or List, optional): The range of quadrature. Default: 10
-            npoints(int, optional): The number of discretization points for quadrature. Default: 200
+            npoints (int, optional): The number of discretization points for quadrature. Default: 100
             plot (bool, optional): Whether to plot the marginal function. Default: ``True``
-            k (int, optional): The marginal function of kth batch to plot. Default: 0
+            k (int, optional): The index of the marginal function within the batch to plot. Default: 0
         """
         # pylint: disable=import-outside-toplevel
         from .gate import PhaseShift

--- a/tests/test_photonic_qmath.py
+++ b/tests/test_photonic_qmath.py
@@ -42,7 +42,7 @@ def test_takagi():
         assert torch.allclose(u @ s_diag @ u.mT, a + 0j, rtol=1e-5, atol=1e-5)
 
 
-def test_quadrature_ladder_transform():
+def test_quadrature_ladder_transform_sq2():
     gate = Squeezing2()
     mat_ladder = gate.update_matrix()
     mat_xxpp = gate.update_transform_xp()[0]

--- a/tests/test_with_qutip.py
+++ b/tests/test_with_qutip.py
@@ -1,0 +1,59 @@
+import deepquantum as dq
+import numpy as np
+import pytest
+import qutip as qp
+import torch
+from deepquantum.photonic import fock_wigner
+
+def test_with_qutip_fock_wigner():
+    r, d = torch.rand(2)
+    cutoff = 50
+    cir1 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='fock', basis=False, cutoff=cutoff)
+    cir1.s(0, r=r, theta=0)
+    cir1.d(0, r=d)
+    cir1.to(torch.double)
+    re  = cir1()
+    psi = re[0]
+    psi = psi.reshape(cutoff, 1)
+    rho = psi @ psi.mH
+
+    npoints = 100
+    qrange = 10
+    prange = 10
+    xvec = np.linspace(-qrange, prange, npoints)
+    pvec = np.linspace(-qrange, prange, npoints)
+    wigner_qp = qp.wigner(qp.Qobj(psi), xvec, pvec, g=1)
+    w = fock_wigner(state=rho, cutoff=cutoff, xvec=xvec, pvec=pvec, den_mat=True)
+    err = torch.sum(abs(w - torch.tensor(wigner_qp.mT)), dim=[1,2])
+    assert err < 1e-6
+
+def test_with_qutip_bosonic_wigner():
+    r, d = torch.rand(2)
+    cutoff = 100
+    cir1 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='fock', basis=False, cutoff=cutoff)
+    cir1.s(0, r=r, theta=0)
+    cir1.d(0, r=d)
+    cir1.to(torch.double)
+    re  = cir1()
+    psi = re[0]
+    psi = psi.reshape(cutoff, 1)
+    rho = psi @ psi.mH
+
+    cir2 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='bosonic')
+    cir2.s(0, r=r, theta=0)
+    cir2.d(0, r=d)
+    cir2.to(torch.double)
+    re2 = cir2()
+    bosonic_state = dq.BosonicState(re2)
+
+    npoints = 100
+    qrange = 10
+    prange = 10
+    xvec = np.linspace(-qrange, prange, npoints)
+    pvec = np.linspace(-qrange, prange, npoints)
+    wigner_qp = qp.wigner(qp.Qobj(psi), xvec, pvec, g=1)
+    wigner_dq = bosonic_state.wigner(wire=0, qrange=qrange, prange=prange, npoints=npoints, plot=False)
+    err = torch.sum(abs(wigner_dq - torch.tensor(wigner_qp.mT)), dim=[1,2])
+    assert err < 1e-2
+
+

--- a/tests/test_with_qutip.py
+++ b/tests/test_with_qutip.py
@@ -15,7 +15,6 @@ def test_with_qutip_fock_wigner():
     fock_state = dq.FockState(state=re, basis=False)
     psi = re[0]
     psi = psi.reshape(cutoff, 1)
-    rho = psi @ psi.mH
 
     npoints = 100
     xrange = 10
@@ -37,7 +36,6 @@ def test_with_qutip_gaussian_wigner():
     re  = cir1()
     psi = re[0]
     psi = psi.reshape(cutoff, 1)
-    rho = psi @ psi.mH
 
     cir2 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='gaussian')
     cir2.s(0, r=r, theta=0)

--- a/tests/test_with_qutip.py
+++ b/tests/test_with_qutip.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 import qutip as qp
 import torch
-from deepquantum.photonic import fock_wigner
 
 def test_with_qutip_fock_wigner():
     r, d = torch.rand(2)
@@ -13,21 +12,22 @@ def test_with_qutip_fock_wigner():
     cir1.d(0, r=d)
     cir1.to(torch.double)
     re  = cir1()
+    fock_state = dq.FockState(state=re, basis=False)
     psi = re[0]
     psi = psi.reshape(cutoff, 1)
     rho = psi @ psi.mH
 
     npoints = 100
-    qrange = 10
+    xrange = 10
     prange = 10
-    xvec = np.linspace(-qrange, prange, npoints)
-    pvec = np.linspace(-qrange, prange, npoints)
+    xvec = np.linspace(-xrange, xrange, npoints)
+    pvec = np.linspace(-prange, prange, npoints)
     wigner_qp = qp.wigner(qp.Qobj(psi), xvec, pvec, g=1)
-    w = fock_wigner(state=rho, cutoff=cutoff, xvec=xvec, pvec=pvec, den_mat=True)
+    w = fock_state.wigner(wire=0, xrange=xrange, prange=prange, npoints=npoints, plot=False)
     err = torch.sum(abs(w - torch.tensor(wigner_qp.mT)), dim=[1,2])
     assert err < 1e-6
 
-def test_with_qutip_bosonic_wigner():
+def test_with_qutip_gaussian_wigner():
     r, d = torch.rand(2)
     cutoff = 100
     cir1 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='fock', basis=False, cutoff=cutoff)
@@ -39,21 +39,19 @@ def test_with_qutip_bosonic_wigner():
     psi = psi.reshape(cutoff, 1)
     rho = psi @ psi.mH
 
-    cir2 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='bosonic')
+    cir2 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='gaussian')
     cir2.s(0, r=r, theta=0)
     cir2.d(0, r=d)
     cir2.to(torch.double)
     re2 = cir2()
-    bosonic_state = dq.BosonicState(re2)
+    gaussian_state = dq.GaussianState(re2)
 
     npoints = 100
-    qrange = 10
+    xrange = 10
     prange = 10
-    xvec = np.linspace(-qrange, prange, npoints)
-    pvec = np.linspace(-qrange, prange, npoints)
+    xvec = np.linspace(-xrange, xrange, npoints)
+    pvec = np.linspace(-prange, prange, npoints)
     wigner_qp = qp.wigner(qp.Qobj(psi), xvec, pvec, g=1)
-    wigner_dq = bosonic_state.wigner(wire=0, qrange=qrange, prange=prange, npoints=npoints, plot=False)
+    wigner_dq = gaussian_state.wigner(wire=0, xrange=xrange, prange=prange, npoints=npoints, plot=False)
     err = torch.sum(abs(wigner_dq - torch.tensor(wigner_qp.mT)), dim=[1,2])
     assert err < 1e-2
-
-


### PR DESCRIPTION
1. Fix bugs in ``BosonicState.wigner`` function
 - Error when computing the Wigner function of a Gaussian state with ``ncom=1``
<img width="918" height="659" alt="image" src="https://github.com/user-attachments/assets/4f0d8b4f-c7e4-404b-a1bc-a357184ed542" />

   -Solution: Squeeze ``exp_imag`` along the last two dimensions to ensure correct broadcasting behavior.
  
   - Unnormalized Wigner function values
<img width="1133" height="563" alt="image" src="https://github.com/user-attachments/assets/a0243c72-eda2-456e-933a-a296e4d98a92" />
   - Solution: Apply an explicit renormalization factor
   
   A comparison with the reference implementation in QuTiP is as follows,
<img width="694" height="454" alt="image" src="https://github.com/user-attachments/assets/ada9cb15-d84d-44a5-9879-7db49cfcd316" />

2. Add function ``fock_wigner`` for Wigner function implementation from Fock state tensor
 
- Example
```
device = 'cpu'
r=1
d=0
cutoff = 30
cir1 = dq.QumodeCircuit(nmode=1, init_state='vac', backend='fock', basis=False, cutoff=cutoff)
cir1.s(0, r=r, theta=0)
cir1.d(0, r=d)
cir1.ps(0, np.pi/3, encode=True)
cir1.to(torch.double)
cir1.to(device)
re  = cir1(data=torch.tensor([[0.],[0.],[0.]], dtype=torch.double, device=device))
s = dq.FockState(state=re, basis=False)
w = s.wigner(wire=0, xrange=10, prange=10, npoints=100, k=0)
```
<img width="1589" height="790" alt="image" src="https://github.com/user-attachments/assets/4d37ac11-e385-477f-842b-26c6d41505ab" />
