### PR TITLE
Support the expectation value of photon number operator and quadrature operator for Fock backend (basis=False)

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1645,7 +1645,7 @@ class QumodeCircuit(Operation):
         wires = sorted(self._convert_indices(wires))
         if self._if_delayloop:
             wires = [self._unroll_dict[wire][-1] for wire in wires]
-        if self.backend == 'fock':
+        if self.backend == 'fock' and not self.basis:
             exp, var = photon_number_mean_var_fock(self.state, self.nmode, self.cutoff, wires, self.den_mat)
         if self.backend in ('gaussian', 'bosonic'):
             if self.backend == 'gaussian':
@@ -1714,7 +1714,7 @@ class QumodeCircuit(Operation):
             phi = torch.stack(phi)
         wires = sorted(self._convert_indices(wires))
         assert len(wires) == len(phi), f'phi length {len(phi)} must match wires length {len(wires)}'
-        if self.backend == 'fock':
+        if self.backend == 'fock' and not self.basis:
             state = self.state
             if self.den_mat:
                 state = state.reshape([-1] + [self.cutoff] * 2 * self.nmode)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1715,8 +1715,8 @@ class QumodeCircuit(Operation):
             for mea in self.measurements:
                 wires = wires + mea.wires
                 phi.append(mea.phi)
-            phi = torch.stack(phi)
-        wires = sorted(self._convert_indices(wires))
+            phi = torch.cat(phi)
+        wires = self._convert_indices(wires)
         assert len(wires) == len(phi), f'phi length {len(phi)} must match wires length {len(wires)}'
         if self.backend == 'fock':
             assert not self.basis

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -29,7 +29,8 @@ from .hafnian_ import hafnian
 from .measurement import Homodyne, Generaldyne
 from .operation import Operation, Gate, Channel, Delay
 from .qmath import fock_combinations, permanent, product_factorial, sort_dict_fock_basis, sub_matrix
-from .qmath import photon_number_mean_var, measure_fock_tensor, sample_homodyne_fock, sample_reject_bosonic
+from .qmath import measure_fock_tensor, sample_homodyne_fock, sample_reject_bosonic
+from .qmath import photon_number_mean_var_cv, photon_number_mean_var_fock, quadrature_mean_fock
 from .qmath import quadrature_to_ladder, shift_func, align_shape, williamson
 from .state import FockState, GaussianState, BosonicState, CatState, GKPState, DistributedFockState
 from .state import combine_bosonic_states
@@ -1637,46 +1638,69 @@ class QumodeCircuit(Operation):
                 integers specifying the indices of the wires. Default: ``None`` (which means all wires are
                 measured)
         """
-        assert self.backend in ('gaussian', 'bosonic')
         if self.state is None:
             return
-        assert isinstance(self.state, list), 'NOT valid when "is_prob" is True'
-        if self.backend == 'gaussian':
-            cov, mean = self.state
-        elif self.backend == 'bosonic':
-            cov, mean, weight = self.state
         if wires is None:
             wires = self.wires
         wires = sorted(self._convert_indices(wires))
         if self._if_delayloop:
             wires = [self._unroll_dict[wire][-1] for wire in wires]
-        shape_cov = cov.shape
-        shape_mean = mean.shape
-        batch = shape_cov[0]
-        nwire = len(wires)
-        cov = cov.reshape(-1, *shape_cov[-2:])
-        mean = mean.reshape(-1, *shape_mean[-2:])
-        covs, means = self._get_local_covs_means(cov, mean, wires)
-        if self.backend == 'gaussian':
-            weights = None
-        elif self.backend == 'bosonic':
-            covs = covs.reshape(*shape_cov[:2], nwire, 2, 2).transpose(1, 2)
-            covs = covs.reshape(-1, shape_cov[-3], 2, 2) # (batch*nwire, ncomb, 2, 2)
-            means = means.reshape(*shape_mean[:2], nwire, 2, 1).transpose(1, 2)
-            means = means.reshape(-1, shape_mean[-3], 2, 1)
-            if weight.shape[0] == 1:
-                weights = weight
-            else:
-                weights = torch.stack([weight] * nwire, dim=-2).reshape(batch * nwire, weight.shape[-1])
-            ncomb = weights.shape[-1]
-            if covs.shape[1] == 1:
-                covs = covs.expand(-1, ncomb, -1, -1)
-            if means.shape[1] == 1:
-                means = means.expand(-1, ncomb, -1, -1)
-        exp, var = photon_number_mean_var(covs, means, weights)
-        exp = exp.reshape(batch, nwire).squeeze()
-        var = var.reshape(batch, nwire).squeeze()
+        if self.backend == 'fock':
+            exp, var = photon_number_mean_var_fock(self.state, self.nmode, self.cutoff, wires, self.den_mat)
+        if self.backend in ('gaussian', 'bosonic'):
+            if self.backend == 'gaussian':
+                cov, mean = self.state
+            elif self.backend == 'bosonic':
+                cov, mean, weight = self.state
+            shape_cov = cov.shape
+            shape_mean = mean.shape
+            batch = shape_cov[0]
+            nwire = len(wires)
+            cov = cov.reshape(-1, *shape_cov[-2:])
+            mean = mean.reshape(-1, *shape_mean[-2:])
+            covs, means = self._get_local_covs_means(cov, mean, wires)
+            if self.backend == 'gaussian':
+                weights = None
+            elif self.backend == 'bosonic':
+                covs = covs.reshape(*shape_cov[:2], nwire, 2, 2).transpose(1, 2)
+                covs = covs.reshape(-1, shape_cov[-3], 2, 2) # (batch*nwire, ncomb, 2, 2)
+                means = means.reshape(*shape_mean[:2], nwire, 2, 1).transpose(1, 2)
+                means = means.reshape(-1, shape_mean[-3], 2, 1)
+                if weight.shape[0] == 1:
+                    weights = weight
+                else:
+                    weights = torch.stack([weight] * nwire, dim=-2).reshape(batch * nwire, weight.shape[-1])
+                ncomb = weights.shape[-1]
+                if covs.shape[1] == 1:
+                    covs = covs.expand(-1, ncomb, -1, -1)
+                if means.shape[1] == 1:
+                    means = means.expand(-1, ncomb, -1, -1)
+            exp, var = photon_number_mean_var_cv(covs, means, weights)
+            exp = exp.reshape(batch, nwire).squeeze()
+            var = var.reshape(batch, nwire).squeeze()
         return exp, var
+
+    def quadrature_mean(
+        self,
+        wires: Union[int, List[int], None] = None,
+        phi: Any = None
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+        """Get the expectation value of the quadratuere operator :math:`\hat{X}\cos\phi + \hat{P}\sin\phi`.
+
+        Args:
+            wires (int, List[int] or None, optional): The wires to measure. It can be an integer or a list of
+                integers specifying the indices of the wires. Default: ``None`` (which means all wires are
+                measured)
+        """
+        if self.backend == 'fock':
+            if wires is None:
+                wires = self.wires
+            wires = sorted(self._convert_indices(wires))
+            mean = quadrature_mean_fock(self.state, self.nmode, self.cutoff, wires, self.den_mat)
+            return mean
+        if self.backend in ('gaussian', 'bosonic'):
+            mean = self.state[1]
+        return mean
 
     def _get_local_covs_means(
         self,

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -346,7 +346,7 @@ def quadrature_mean_fock(
 ) -> torch.Tensor:
     """Get the expectation value of the quadrature x for Fock state tensors."""
     coef = 2 * dqp.kappa ** 2 / dqp.hbar
-    factor = torch.sqrt(torch.arange(1, cutoff, device=state.device, dtype=torch.float64) / 2)
+    factor = torch.sqrt(torch.arange(1, cutoff, device=state.device, dtype=state.real.dtype) / 2)
     mean = []
     if den_mat:
         state = state.reshape(-1, cutoff ** nmode, cutoff ** nmode)
@@ -355,7 +355,7 @@ def quadrature_mean_fock(
             reduced_dm = partial_trace(state, nmode, trace_lst, cutoff) # (batch, cutoff, cutoff)
             reduced_dm = reduced_dm.reshape(-1, cutoff, cutoff)
             off_diag = reduced_dm.diagonal(offset=1, dim1=1, dim2=2) # rho_{n, n+1}
-            term = factor * 2 * (off_diag).real # only with real part contribution
+            term = factor * 2 * off_diag.real # only with real part contribution
             mean.append(term.sum(dim=1))
     else:
         if state.ndim == nmode:

--- a/tests/test_with_pennylane.py
+++ b/tests/test_with_pennylane.py
@@ -1,0 +1,62 @@
+import deepquantum as dq
+import numpy as np
+import pennylane as qml
+import torch
+
+
+
+def test_number_operator_exp():
+    nmode = 4
+    cutoff = 4
+    sq = np.random.rand(nmode)
+    bs_angles = np.random.rand(nmode-1, 2) * 2 * np.pi
+    dev = qml.device("strawberryfields.fock", wires=nmode, cutoff_dim=cutoff)
+    @qml.qnode(dev)
+    def circuit():
+        for i in range(nmode):
+            qml.Squeezing(sq[i], 0.0, wires=i)
+            if i < nmode-1:
+                qml.Beamsplitter(theta=bs_angles[i][0], phi=bs_angles[i][1], wires=[i, i+1])
+        exp = qml.expval(qml.NumberOperator(0)) # number operator
+        exp1 = qml.expval(qml.NumberOperator(1))
+        exp2 = qml.expval(qml.NumberOperator(2))
+        exp3 = qml.expval(qml.NumberOperator(3))
+        return exp, exp1, exp2, exp3
+    exp_qml = circuit()
+    cir = dq.QumodeCircuit(nmode=nmode, backend='fock', basis=False, cutoff=cutoff, init_state='vac', den_mat=True)
+    for i in range(nmode):
+        cir.s(i, sq[i], encode=True)
+        if i < nmode-1:
+            cir.bs(wires=[i, i+1], inputs=bs_angles[i])
+    state = cir()
+    exp_dq, _ = cir.photon_number_mean_var()
+    assert (exp_dq.flatten() - exp_qml.numpy()).sum() < 1e-6
+
+
+def test_quadrature_operator_exp():
+    nmode = 4
+    cutoff = 4
+    sq = np.random.rand(nmode)
+    bs_angles = np.random.rand(nmode-1, 2) * 2 * np.pi
+    phi = np.random.rand(nmode) * 2 * np.pi
+    dev = qml.device("strawberryfields.fock", wires=nmode, cutoff_dim=cutoff)
+    @qml.qnode(dev)
+    def circuit():
+        for i in range(nmode):
+            qml.Squeezing(sq[i], 0.0, wires=i)
+            if i < nmode-1:
+                qml.Beamsplitter(theta=bs_angles[i][0], phi=bs_angles[i][1], wires=[i, i+1])
+        exp = []
+        for i in range(nmode):
+            exp.append(qml.expval(qml.QuadOperator(phi=phi[i], wires=i))) # Quadrature X, P
+            return exp
+    exp_qml = circuit()
+    cir = dq.QumodeCircuit(nmode=nmode, backend='fock', basis=False, cutoff=cutoff, init_state='vac', den_mat=True)
+    for i in range(nmode):
+        cir.s(i, sq[i], encode=True)
+        if i < nmode-1:
+            cir.bs(wires=[i, i+1], inputs=bs_angles[i])
+    cir.to(torch.double)
+    state = cir()
+    exp_dq = cir.quadrature_mean(wires=list(range(nmode)), phi=list(phi))
+    assert (exp_dq.flatten() - exp_qml.numpy()).sum() < 1e-6

--- a/tests/test_with_pennylane.py
+++ b/tests/test_with_pennylane.py
@@ -4,7 +4,6 @@ import pennylane as qml
 import torch
 
 
-
 def test_number_operator_exp():
     nmode = 4
     cutoff = 4
@@ -60,3 +59,4 @@ def test_quadrature_operator_exp():
     state = cir()
     exp_dq = cir.quadrature_mean(wires=list(range(nmode)), phi=list(phi))
     assert (exp_dq.flatten() - exp_qml.numpy()).sum() < 1e-6
+


### PR DESCRIPTION
This PR adds support for expectation value calculations of photon number operator and quadrature operator in the Fock backend when `basis=False`.
- Extend  `photon_number_mean_var` to support expectation value and variance calculation for photon number operator
 in the Fock backend when `basis=False`.
```
device = 'cpu'
nmode = 4
cutoff = 4
np.random.seed(42)
sq = np.random.rand(nmode)
bs_angles = np.random.rand(nmode-1, 2) * 2 * np.pi

cir = dq.QumodeCircuit(nmode=nmode, backend='fock', basis=False, cutoff=cutoff, init_state='vac', den_mat=False)
for i in range(nmode):
    cir.s(i, sq[i], encode=True)
    if i < nmode-1:
        cir.bs(wires=[i, i+1], inputs=bs_angles[i])
cir.to(device)
state = cir()
exp, var = cir.photon_number_mean_var()
print('expectation values:', exp)
print('variance:', var)
```
- Add `quadrature_mean`  to support  expectation value calculation for quadrature operator in the Fock backend when `basis=False`.
```
device = 'cpu'
nmode = 4
cutoff = 4
np.random.seed(42)
sq = np.random.rand(nmode)
dis = np.random.rand(nmode)
phi = np.random.rand(nmode) * 2 * np.pi

cir = dq.QumodeCircuit(nmode=nmode, backend='fock', basis=False, cutoff=cutoff, init_state='vac', den_mat=True)
for i in range(nmode):
    cir.s(i, sq[i])
    cir.d(i, dis[i], encode = True)
    cir.homodyne(i, phi[i])
cir.to(device)
cir.to(torch.double)
state = cir()
mean = cir.quadrature_mean()
print('expectation values:', mean)
```

- Add test file `test_with_pennylane.py`  to validate results against PennyLane.
