### PR TITLE
Support vmap over multiple instances of QumodeCircuit

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1426,7 +1426,8 @@ class QumodeCircuit(Operation):
         """Sample the output states for Fock backend via SC-MCMC method."""
         self._init_state = init_state
         self._unitary = unitary
-        self._all_fock_basis = self._get_all_fock_basis(init_state)
+        if self._all_fock_basis is None:
+            self._all_fock_basis = self._get_all_fock_basis(init_state)
         merged_samples = sample_sc_mcmc(prob_func=self._get_prob_fock,
                                         proposal_sampler=self._proposal_sampler,
                                         shots=shots,

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -581,9 +581,9 @@ class QumodeCircuit(Operation):
             state (Any, optional): The output fock basis states. Default: ``None``
         """
         assert self.basis
+        assert self.init_state.state.ndim == 1, 'Manually settings for batched init_state are not needed.'
         if state is None:
             state = self.init_state.state
-            assert state.ndim == 1, 'Manually settings for batched init_state are not needed.'
             if self._lossy:
                 state = torch.cat([state, state.new_zeros(self._nloss)], dim=-1)
             self._all_fock_basis = self._get_all_fock_basis(state)
@@ -591,8 +591,8 @@ class QumodeCircuit(Operation):
             state = FockState(state).state
             if state.ndim == 1:
                 state = state.unsqueeze(0)
-            # assert torch.all(state.sum(dim=-1) == self.init_state.state.sum()), \
-            #     "The number of photons must be the same and equal to initial states."
+            assert torch.all(state.sum(dim=-1) == state[0].sum(dim=-1)), \
+                "The number of photons must be the same and equal to initial states."
             assert state.shape[-1] == self.nmode + self._nloss, \
                 'Please fill in right number of modes (including all ancilla modes in lossy case.)'
             self._all_fock_basis = state

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -58,6 +58,8 @@ class QumodeCircuit(Operation):
             Default: ``False``
         detector (str, optional): For Gaussian backend, use ``'pnrd'`` for the photon-number-resolving detector
             or ``'threshold'`` for the threshold detector. Default: ``'pnrd'``
+        sort (bool, optional): Whether to sort dictionary of Fock basis states in the descending order of probs.
+            Default: ``True``
         name (str or None, optional): The name of the circuit. Default: ``None``
         mps (bool, optional): Whether to use matrix product state representation. Default: ``False``
         chi (int or None, optional): The bond dimension for matrix product state representation.
@@ -75,6 +77,7 @@ class QumodeCircuit(Operation):
         basis: bool = True,
         den_mat: bool = False,
         detector: str = 'pnrd',
+        sort: bool = True,
         name: Optional[str] = None,
         mps: bool = False,
         chi: Optional[int] = None,
@@ -104,7 +107,7 @@ class QumodeCircuit(Operation):
         self._is_batch_expand = False # whether batch states are expanded out of photons conservation
         self._expand_state = None # expanded state (init_state + lossy + batch expand)
         self._all_fock_basis = None
-        self.sort = True
+        self.sort = sort
         # TDM
         self._if_delayloop = False
         self._nmode_tdm = self.nmode

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -593,7 +593,7 @@ class QumodeCircuit(Operation):
             self._all_fock_basis = state
 
     def get_fock_basis(self) -> None:
-        """Get output fock basis states according to the current design.
+        """Get output fock basis states according to the current settings.
 
         Returns:
             Union[List[torch.Tensor], Dict]: The final Gaussian (Bosonic) state or a dictionary of probabilities.

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -589,6 +589,8 @@ class QumodeCircuit(Operation):
             self._all_fock_basis = self._get_all_fock_basis(state)
         else:
             state = FockState(state).state
+            if state.ndim == 1:
+                state = state.unsqueeze(0)
             # assert torch.all(state.sum(dim=-1) == self.init_state.state.sum()), \
             #     "The number of photons must be the same and equal to initial states."
             assert state.shape[-1] == self.nmode + self._nloss, \

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -173,6 +173,8 @@ class FockState(nn.Module):
 
     def __hash__(self) -> int:
         """Compute the hash value for the ``FockState``."""
+        if self.state.device.type == 'meta':
+            return hash(id(self))
         if self.basis:
             # Hash Fock basis state as a string
             state_str = ''.join(map(str, self.state.tolist()))


### PR DESCRIPTION
New features:

- `set_fock_basis()`: allow users manually set fock basis states before forward
- `get_fock_basis()`: check the output fock basis states in current settings
- optional bool arg `sort` of forward could decide whether to sort dictionary of Fock basis states in the descending order of probs. If `sort=False`, the dictionary will be in the lexicographic order.

Miscellaneous:
- update `get_unitary`: replacing in-place operations with out-of-place ops `index_put` to support `vmap`
- support return hash value of `FockState` on `meta` devices.
- fix typos

Example use case:
```python
import torch
import torch.nn as nn

class BS(nn.Module):
    def __init__(self):
        super().__init__()
        cir = dq.QumodeCircuit(nmode=3, init_state=[1,1,0])
        cir.bs([0,1], encode=True)
        cir.ps([1], encode=True)
        cir.bs([1,2])
        cir.set_fock_basis() # set all fock basis before vmap
        self.cir = cir

    def forward(self, x):
        d = self.cir(x, is_prob=True, sort=False) # forward without extra sorting
        sorted_items = d.items()
        sorted_values = [v for k, v in sorted_items]
        probs = torch.cat(sorted_values,dim=1)
        return probs

num_models = 5
batch_size = 64

models = [BS() for i in range(num_models)]
data = torch.randn(batch_size, 3)

def wrapper(params, buffers, data):
    return torch.func.functional_call(models[0], (params, buffers), data)

params, buffers = torch.func.stack_module_state(models)
output = vmap(wrapper, (0, 0, None))(params, buffers, data)

print(output.shape)
```
