### PR TITLE
Exclude symlinks from pre-commit to fix Windows compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: ^docs/source/(demos|tutorials)$
       - id: end-of-file-fixer
+        exclude: ^docs/source/(demos|tutorials)$
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
**Summary**
This PR fixes an issue where pre-commit hooks (`end-of-file-fixer` / `trailing-whitespace`) were incorrectly modifying symlink files on Windows environments.

**The Problem**
On Windows (without `core.symlinks` enabled), Git checks out symlinks as plain text files containing the target path. Pre-commit hooks treat these as regular text files and force a newline at the end (or modify whitespace), causing "dirty" file changes and unnecessary diffs for Windows users.

**The Fix**
Updated `.pre-commit-config.yaml` to exclude the following symlinks from inspection:
- `docs/source/demos`
- `docs/source/tutorials`