### PR TITLE
Fix chain-rule sampling with threshold detector for Gaussian backend (#146)

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1547,7 +1547,7 @@ class QumodeCircuit(Operation):
             sample = torch.randint(0, self.cutoff, [nmode])
         return sample
 
-    def _generate_chain_sample(self, wires: int | list[int] | None = None, detector: str = None) -> torch.Tensor:
+    def _generate_chain_sample(self, wires: list[int], detector: str) -> torch.Tensor:
         """Generate batched random samples via chain rule.
 
         Args:
@@ -1560,9 +1560,6 @@ class QumodeCircuit(Operation):
         Returns:
             torch.Tensor: Tensor of shape (batch, nwire).
         """
-        if wires is None:
-            wires = self.wires
-        wires = sorted(self._convert_indices(wires))
         sample = []
         if self.backend == 'fock':
             assert self.mps

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1555,7 +1555,7 @@ class QumodeCircuit(Operation):
                 integers specifying the indices of the wires. Default: ``None`` (which means all wires are
                 measured)
             detector (str): For Gaussian backend, use ``'pnrd'`` for the photon-number-resolving detector
-            or ``'threshold'`` for the threshold detector.
+                or ``'threshold'`` for the threshold detector.
 
         Returns:
             torch.Tensor: Tensor of shape (batch, nwire).

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1467,7 +1467,7 @@ class QumodeCircuit(Operation):
             print('Using chain-rule method to sample the final states!')
             samples = []
             for _ in range(shots):
-                sample = self._generate_chain_sample(wires)
+                sample = self._generate_chain_sample(wires, detector)
                 samples.append(sample)
             samples = torch.stack(samples).permute(1, 0, 2)  # (batch, shots, wires)
             for i in range(batch):
@@ -1547,13 +1547,15 @@ class QumodeCircuit(Operation):
             sample = torch.randint(0, self.cutoff, [nmode])
         return sample
 
-    def _generate_chain_sample(self, wires: int | list[int] | None = None) -> torch.Tensor:
+    def _generate_chain_sample(self, wires: int | list[int] | None = None, detector: str = None) -> torch.Tensor:
         """Generate batched random samples via chain rule.
 
         Args:
             wires (int, List[int] or None, optional): The wires to measure. It can be an integer or a list of
                 integers specifying the indices of the wires. Default: ``None`` (which means all wires are
                 measured)
+            detector (str): For Gaussian backend, use ``'pnrd'`` for the photon-number-resolving detector
+            or ``'threshold'`` for the threshold detector.
 
         Returns:
             torch.Tensor: Tensor of shape (batch, nwire).
@@ -1575,10 +1577,10 @@ class QumodeCircuit(Operation):
                 mps[i] = torch.gather(mps[i], dim=2, index=index)
             sample = torch.stack(sample, dim=-1).squeeze(1)
         elif self.backend == 'gaussian':  # chain rule for GBS
-            sample = self._generate_chain_sample_gaussian(wires)
+            sample = self._generate_chain_sample_gaussian(wires, detector)
         return sample
 
-    def _generate_chain_sample_gaussian(self, wires: list[int]) -> torch.Tensor:
+    def _generate_chain_sample_gaussian(self, wires: list[int], detector: str) -> torch.Tensor:
         """Generate batched random samples via chain rule for Gaussian backend.
 
         See https://research-information.bris.ac.uk/en/studentTheses/classical-simulations-of-gaussian-boson-sampling
@@ -1640,12 +1642,13 @@ class QumodeCircuit(Operation):
         purity = GaussianState(self.state).is_pure
         cov, mean = self.state
         batch = cov.shape[0]
+        cutoff = 2 if detector == 'threshold' else self.cutoff
         if purity:
             for i in range(batch):
-                sample.append(_sample_pure(cov[i], mean[i], wires, self.nmode, self.cutoff, self.detector))
+                sample.append(_sample_pure(cov[i], mean[i], wires, self.nmode, cutoff, detector))
         else:
             for i in range(batch):
-                sample.append(_sample_mixed(cov[i], mean[i], wires, self.nmode, self.cutoff, self.detector))
+                sample.append(_sample_mixed(cov[i], mean[i], wires, self.nmode, cutoff, detector))
         sample = torch.stack(sample)
         return sample
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1551,9 +1551,8 @@ class QumodeCircuit(Operation):
         """Generate batched random samples via chain rule.
 
         Args:
-            wires (int, List[int] or None, optional): The wires to measure. It can be an integer or a list of
-                integers specifying the indices of the wires. Default: ``None`` (which means all wires are
-                measured)
+            wires (List[int]): The wires to measure. It can be a list of integers specifying the indices
+                of the wires.
             detector (str): For Gaussian backend, use ``'pnrd'`` for the photon-number-resolving detector
                 or ``'threshold'`` for the threshold detector.
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -1551,7 +1551,7 @@ class QumodeCircuit(Operation):
         """Generate batched random samples via chain rule.
 
         Args:
-            wires (List[int]): The wires to measure. It can be a list of integers specifying the indices
+            wires (list[int]): The wires to measure. It can be a list of integers specifying the indices
                 of the wires.
             detector (str): For Gaussian backend, use ``'pnrd'`` for the photon-number-resolving detector
                 or ``'threshold'`` for the threshold detector.


### PR DESCRIPTION
Fix inconsistent sampling results of GBS with detector='threshold' using chain-rule method by adding adaptive `cutoff` when using chain-rule sampling.
code:
```
theta = torch.rand(1) * torch.pi
# Initialize a 2-mode circuit with cutoff=5
cir = dq.QumodeCircuit(2, 'vac', cutoff=5, backend='gaussian')
# Define trainable parameters
r0 = torch.tensor(0.5)
r1 = torch.tensor(1.0)
# Add squeezing gates
cir.s(0, r=r0)
cir.s(1, r=r1)
# Define trainable parameter for beamsplitter
# theta = torch.nn.Parameter(torch.tensor(1.0))

# Add a beamsplitter gate
cir.bs([0, 1], inputs=[theta, 1])
# Forward process
cir()

# Print the measurement results
# with different detectors
sample = cir.measure(shots=1000, detector='threshold')
# sample = cir.measure(shots=100, detector='pnrd')
prob = cir(is_prob=True, detector='threshold')
print(sample)
print(prob)
```
<img width="1346" height="941" alt="image" src="https://github.com/user-attachments/assets/113d5561-eb31-428e-ac22-a68dd52958b7" />
