### PR TITLE
Fix Apple Silicon MPS compatibility and refactor native dtype/device casting

### DIFF
--- a/src/deepquantum/__init__.py
+++ b/src/deepquantum/__init__.py
@@ -3,6 +3,8 @@
 __version__ = '4.4.0'
 
 
+import torch
+
 from . import (
     adjoint,
     ansatz,
@@ -109,3 +111,8 @@ from .photonic import (
 from .qasm3 import cir_to_qasm3, qasm3_to_cir
 from .qmath import amplitude_encoding, expectation, measure, meyer_wallach_measure, multi_kron, partial_trace
 from .state import DistributedQubitState, MatrixProductState, QubitState
+
+dtype_map = {
+    torch.float: torch.cfloat,
+    torch.double: torch.cdouble,
+}

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -177,19 +177,6 @@ class QubitCircuit(Operation):
         cir.wires_condition = list(set(cir.wires_condition))
         return cir
 
-    def to(self, arg: Any) -> 'QubitCircuit':
-        """Set dtype or device of the ``QubitCircuit``."""
-        self.init_state.to(arg)
-        if arg in (torch.float, torch.double):
-            for op in self.operators:
-                op.to(arg)
-            for ob in self.observables:
-                ob.to(arg)
-        else:
-            self.operators.to(arg)
-            self.observables.to(arg)
-        return self
-
     def forward(
         self,
         data: torch.Tensor | None = None,
@@ -413,18 +400,18 @@ class QubitCircuit(Operation):
                     elif basis == 'y':
                         cir_basis.sdg(wire)
                         cir_basis.h(wire)
-                cir_basis.to(dtype).to(device)
+                cir_basis.to(device, dtype)
                 cir_basis(state=self.state)
                 wires = sum(observable.wires, [])
                 samples = cir_basis.measure(shots=shots, wires=wires)
                 if isinstance(samples, list):
                     expval = []
                     for sample in samples:
-                        expval_i = sample2expval(sample=sample).to(dtype).to(device)
+                        expval_i = sample2expval(sample=sample).to(device, dtype)
                         expval.append(expval_i)
                     expval = torch.cat(expval)
                 elif isinstance(samples, dict):
-                    expval = sample2expval(sample=samples).to(dtype).to(device)
+                    expval = sample2expval(sample=samples).to(device, dtype)
                     if (not self.mps and self.state.ndim == 2) or (self.mps and self.state[0].ndim == 3):
                         expval = expval.squeeze(0)
                 out.append(expval)
@@ -1755,13 +1742,13 @@ class DistributedQubitCircuit(QubitCircuit):
                     elif basis == 'y':
                         cir_basis.sdg(wire)
                         cir_basis.h(wire)
-                cir_basis.to(dtype).to(device)
+                cir_basis.to(device, dtype)
                 state = deepcopy(self.state)
                 state = cir_basis(state=state)
                 wires = sum(observable.wires, [])
                 samples = measure_dist(state=state, shots=shots, wires=wires)
                 if self.state.rank == 0:
-                    expval = sample2expval(sample=samples).to(dtype).to(device).squeeze(0)
+                    expval = sample2expval(sample=samples).to(device, dtype).squeeze(0)
                 else:
                     expval = torch.tensor([], dtype=dtype, device=device)
                 out.append(expval)

--- a/src/deepquantum/circuit.py
+++ b/src/deepquantum/circuit.py
@@ -1,5 +1,6 @@
 """Quantum circuit"""
 
+import warnings
 from collections import defaultdict
 from collections.abc import Hashable, Sequence
 from copy import copy, deepcopy
@@ -204,6 +205,19 @@ class QubitCircuit(Operation):
             state = state.tensors
         elif isinstance(state, QubitState):
             state = state.state
+        if isinstance(state, torch.Tensor) and state.device.type == 'mps':
+            max_mps_dim = 16
+            mps_dim = 2 * self.nqubit + 1 if self.den_mat else self.nqubit + 1
+            if mps_dim > max_mps_dim:
+                warnings.warn(
+                    f'Apple Silicon MPS limit ({max_mps_dim} dims) exceeded. Auto-falling back to CPU.',
+                    UserWarning,
+                    stacklevel=4,
+                )
+                self.cpu()
+                state = state.cpu()
+                if isinstance(data, torch.Tensor):
+                    data = data.cpu()
         if self.ndata == 0:
             data = None
         if data is None or data.ndim == 1:

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -611,8 +611,8 @@ class U3Gate(ParametricSingleGate):
     def get_matrix(self, theta: Any, phi: Any, lambd: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
         theta, phi, lambd = self.inputs_to_tensor([theta, phi, lambd])
-        cos_t = torch.cos(theta / 2)
-        sin_t = torch.sin(theta / 2)
+        cos_t = torch.cos(theta / 2) + 0j
+        sin_t = torch.sin(theta / 2) + 0j
         e_il = torch.exp(1j * lambd)
         e_ip = torch.exp(1j * phi)
         e_ipl = torch.exp(1j * (phi + lambd))
@@ -1482,7 +1482,7 @@ class Rx(ParametricSingleGate):
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
         theta = self.inputs_to_tensor(theta)
-        cos = torch.cos(theta / 2)
+        cos = torch.cos(theta / 2) + 0j
         isin = torch.sin(theta / 2) * 1j
         return torch.stack([cos, -isin, -isin, cos]).reshape(2, 2)
 
@@ -1797,12 +1797,12 @@ class ProjectionJ(ParametricSingleGate):
         """Get the local unitary matrix."""
         theta = self.inputs_to_tensor(theta)
         if self.plane in ['xy', 'yx']:
-            one = torch.ones_like(theta)
+            one = torch.ones_like(theta) + 0j
             e_m_theta = torch.exp(-1j * theta)
             return torch.stack([one, e_m_theta, one, -e_m_theta]).reshape(2, 2) / 2**0.5
         elif self.plane in ['yz', 'zy']:
-            c_p_s = torch.cos(theta / 2) + torch.sin(theta / 2)
-            c_m_s = torch.cos(theta / 2) - torch.sin(theta / 2)
+            c_p_s = torch.cos(theta / 2) + torch.sin(theta / 2) + 0j
+            c_m_s = torch.cos(theta / 2) - torch.sin(theta / 2) + 0j
             return torch.stack([c_p_s, -1j * c_m_s, c_m_s, 1j * c_p_s]).reshape(2, 2) / 2**0.5
         elif self.plane in ['zx', 'xz']:
             cos = torch.cos(theta / 2)
@@ -2427,7 +2427,7 @@ class Rxy(ParametricDoubleGate):
     def get_matrix(self, theta: Any) -> torch.Tensor:
         """Get the local unitary matrix."""
         theta = self.inputs_to_tensor(theta)
-        cos = torch.cos(theta / 2)
+        cos = torch.cos(theta / 2) + 0j
         isin = torch.sin(theta / 2) * 1j
         m1 = torch.eye(1, dtype=theta.dtype, device=theta.device)
         m2 = torch.stack([cos, -isin, -isin, cos]).reshape(2, 2)

--- a/src/deepquantum/gate.py
+++ b/src/deepquantum/gate.py
@@ -11,6 +11,7 @@ from .distributed import dist_many_ctrl_one_targ_gate, dist_one_targ_gate, dist_
 from .operation import Gate
 from .qmath import evolve_state, inverse_permutation, is_unitary, multi_kron, svd
 from .state import DistributedQubitState
+from .utils import apply_complex_fix
 
 if TYPE_CHECKING:
     from .qpd import MoveQPD
@@ -2988,22 +2989,14 @@ class HamiltonianGate(ArbitraryGate):
         self.register_buffer('z', PauliZ().matrix)
         self.init_para([hamiltonian, t])
 
-    def to(self, arg: Any) -> 'HamiltonianGate':
-        """Set dtype or device of the ``HamiltonianGate``."""
-        if arg == torch.float:
-            self.x = self.x.to(torch.cfloat)
-            self.y = self.y.to(torch.cfloat)
-            self.z = self.z.to(torch.cfloat)
-            self.ham_tsr = self.ham_tsr.to(torch.cfloat)
-            self.t = self.t.to(torch.float)
-        elif arg == torch.double:
-            self.x = self.x.to(torch.cdouble)
-            self.y = self.y.to(torch.cdouble)
-            self.z = self.z.to(torch.cdouble)
-            self.ham_tsr = self.ham_tsr.to(torch.cdouble)
-            self.t = self.t.to(torch.double)
-        else:
-            super().to(arg)
+    def _apply(self, fn: Any) -> 'HamiltonianGate':
+        tensors_dict = {}
+        names = ['x', 'y', 'z', 'ham_tsr']
+        tensors_dict = {name: tensor for name in names if (tensor := self._buffers.pop(name)) is not None}
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     def _convert_hamiltonian(self, hamiltonian: list) -> list[list]:
@@ -3126,10 +3119,6 @@ class Reset(Gate):
         super().__init__(name='Reset', nqubit=nqubit, wires=wires, tsr_mode=tsr_mode)
         self.postselect = postselect
 
-    def to(self, arg: Any) -> 'Reset':
-        """Set dtype or device of the ``Reset``."""
-        return self
-
     def op_state(self, x: torch.Tensor) -> torch.Tensor:
         """Perform a forward pass for state vectors."""
         if len(self.wires) == self.nqubit:
@@ -3196,10 +3185,6 @@ class Barrier(Gate):
         super().__init__(name=name, nqubit=nqubit, wires=wires)
         self.nancilla = 0
 
-    def to(self, arg: Any) -> 'Barrier':
-        """Set dtype or device of the ``Barrier``."""
-        return self
-
     def forward(self, x: Any) -> Any:
         """Perform a forward pass."""
         return x
@@ -3250,12 +3235,6 @@ class Move(DoubleGate):
         reset = Reset(nqubit=nqubit, wires=self.wires[1], postselect=postselect, tsr_mode=True)
         swap = Swap(nqubit=nqubit, wires=self.wires, tsr_mode=True)
         self.gates = nn.Sequential(reset, swap)
-
-    def to(self, arg: Any) -> 'Move':
-        """Set dtype or device of the ``Move``."""
-        for gate in self.gates:
-            gate.to(arg)
-        return self
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Perform a forward pass."""

--- a/src/deepquantum/mbqc/pattern.py
+++ b/src/deepquantum/mbqc/pattern.py
@@ -55,14 +55,6 @@ class Pattern(Operation):
         self.ndata = 0
         self.nodes_out_seq = None
 
-    def to(self, arg: Any) -> 'Pattern':
-        """Set dtype or device of the ``Pattern``."""
-        self.init_state.to(arg)
-        for op in self.commands:
-            if isinstance(op, Measurement):
-                op.to(arg)
-        return self
-
     def forward(self, data: torch.Tensor | None = None, state: GraphState | None = None) -> GraphState:
         """Perform a forward pass of the MBQC pattern and return the final graph state.
 

--- a/src/deepquantum/mbqc/state.py
+++ b/src/deepquantum/mbqc/state.py
@@ -11,6 +11,7 @@ from torch import nn, vmap
 from ..circuit import QubitCircuit
 from ..qmath import inverse_permutation, multi_kron
 from ..state import QubitState
+from ..utils import apply_complex_fix
 
 
 class SubGraphState(nn.Module):
@@ -38,14 +39,16 @@ class SubGraphState(nn.Module):
         self.set_state(state)
         self.measure_dict = defaultdict(list)  # record the measurement results: {node: batched_bit}
 
-    def to(self, arg: Any) -> 'SubGraphState':
-        """Set dtype or device of the ``SubGraphState``."""
-        if arg == torch.float:
-            self.state = self.state.to(torch.cfloat)
-        elif arg == torch.double:
-            self.state = self.state.to(torch.cdouble)
-        else:
-            self.state = self.state.to(arg)
+    def _apply(self, fn: Any) -> 'SubGraphState':
+        tensors_dict = {}
+        name = 'state'
+        tensor = self._buffers.pop(name)
+        if tensor is not None:
+            tensors_dict[name] = tensor
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     @property
@@ -74,7 +77,7 @@ class SubGraphState(nn.Module):
         edges = list(filter(lambda edge: edge[2]['cz'], self.edges(data=True)))
         for edge in edges:
             cir.cz(self.node2wire_dict[edge[0]], self.node2wire_dict[edge[1]])
-        cir.to(init_state.real.dtype).to(init_state.device)
+        cir.to(init_state.device, init_state.real.dtype)
         return cir()
 
     def set_graph(
@@ -230,12 +233,6 @@ class GraphState(nn.Module):
         self.subgraphs = nn.ModuleList([sgs])
         self.nodes_out_seq = None
 
-    def to(self, arg: Any) -> 'GraphState':
-        """Set dtype or device of the ``GraphState``."""
-        for sgs in self.subgraphs:
-            sgs.to(arg)
-        return self
-
     def add_subgraph(
         self,
         nodes_state: int | list[int] | None = None,
@@ -263,7 +260,7 @@ class GraphState(nn.Module):
         if index is None:
             dtype = self.subgraphs[0].state.real.dtype
             device = self.subgraphs[0].state.device
-            sgs.to(dtype).to(device)
+            sgs.to(device, dtype)
         if measure_dict is not None:
             sgs.measure_dict = measure_dict
         if index is None:

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -10,6 +10,7 @@ from torch import nn, vmap
 from .distributed import dist_many_targ_gate
 from .qmath import evolve_den_mat, evolve_state, inverse_permutation, state_to_tensors
 from .state import DistributedQubitState, MatrixProductState
+from .utils import apply_complex_fix
 
 
 class Operation(nn.Module):
@@ -154,20 +155,19 @@ class Gate(Operation):
         self.nodes = self.wires
         self.nancilla = 1
 
-    def to(self, arg: Any) -> 'Gate':
-        """Set dtype or device of the ``Gate``."""
-        if arg == torch.float:
-            if self.npara == 0:
-                self.matrix = self.matrix.to(torch.cfloat)
-            elif self.npara > 0:
-                super().to(torch.float)
-        elif arg == torch.double:
-            if self.npara == 0:
-                self.matrix = self.matrix.to(torch.cdouble)
-            elif self.npara > 0:
-                super().to(torch.double)
-        else:
-            super().to(arg)
+    def _apply(self, fn: Any) -> 'Gate':
+        if self.npara > 0:
+            super()._apply(fn)
+        elif self.npara == 0:
+            tensors_dict = {}
+            name = 'matrix'
+            tensor = self._buffers.pop(name) if name in self._buffers else None  # Consider Reset and Barrier
+            if tensor is not None:
+                tensors_dict[name] = tensor
+            super()._apply(fn)
+            corrected = apply_complex_fix(fn, tensors_dict)
+            for key, value in corrected.items():
+                self.register_buffer(key, value)
         return self
 
     def set_controls(self, controls: int | list[int]) -> None:
@@ -441,12 +441,6 @@ class Layer(Operation):
         # MBQC
         self.nodes = copy(self.wires)
 
-    def to(self, arg: Any) -> 'Layer':
-        """Set dtype or device of the ``Layer``."""
-        for gate in self.gates:
-            gate.to(arg)
-        return self
-
     def get_unitary(self) -> torch.Tensor:
         """Get the global unitary matrix."""
         u = None
@@ -663,7 +657,7 @@ class GateQPD(Gate):
 
     def __init__(
         self,
-        bases: list[tuple[nn.Sequential, ...]],
+        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,
@@ -681,14 +675,6 @@ class GateQPD(Gate):
         self.coeffs = coeffs
         self.label = label
         self.idx = 0
-
-    def to(self, arg: Any) -> 'GateQPD':
-        """Set dtype or device of the ``GateQPD``."""
-        for basis in self.bases:
-            for ops in basis:
-                for op in ops:
-                    op.to(arg)
-        return self
 
     def set_nqubit(self, nqubit: int) -> None:
         """Set the number of qubits of the ``GateQPD``."""

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -657,7 +657,7 @@ class GateQPD(Gate):
 
     def __init__(
         self,
-        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
+        bases: nn.ModuleList,
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,

--- a/src/deepquantum/operation.py
+++ b/src/deepquantum/operation.py
@@ -657,7 +657,7 @@ class GateQPD(Gate):
 
     def __init__(
         self,
-        bases: nn.ModuleList,
+        bases: 'nn.ModuleList[nn.ModuleList[nn.Sequential]]',
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -154,7 +154,7 @@ class QumodeCircuit(Operation):
         self._reset_fock_basis = True  # whether to recompute the output Fock basis states in forward()
         self._init_state_sample = None  # for _sample_mcmc_fock()
         # Bosonic
-        self._bosonic_states = None  # list of initial Bosonic states
+        self._bosonic_states = None  # ModuleList of initial Bosonic states
         # TDM
         self._with_delay = False
         self._nmode_tdm = self.nmode
@@ -255,22 +255,6 @@ class QumodeCircuit(Operation):
         for key, value in rhs._ntau_dict.items():
             cir._ntau_dict[key].extend(value)
         return cir
-
-    def to(self, arg: Any) -> 'QumodeCircuit':
-        """Set dtype or device of the ``QumodeCircuit``."""
-        self.init_state.to(arg)
-        if arg in (torch.float, torch.double):
-            for op in self.operators:
-                op.to(arg)
-            for op_m in self.measurements:
-                op_m.to(arg)
-        else:
-            self.operators.to(arg)
-            self.measurements.to(arg)
-        if self.backend == 'bosonic' and isinstance(self._bosonic_states, list):
-            for bs in self._bosonic_states:
-                bs.to(arg)
-        return self
 
     def forward(
         self,
@@ -1175,7 +1159,7 @@ class QumodeCircuit(Operation):
             else:
                 sub_mat[torch.arange(len(sub_gamma)), torch.arange(len(sub_gamma))] = sub_gamma
             haf = abs(hafnian(sub_mat, loop=loop)) ** 2 if purity else hafnian(sub_mat, loop=loop)
-            prob = p_vac * haf / product_factorial(final_state).to(device=haf.device, dtype=haf.dtype)
+            prob = p_vac * haf / product_factorial(final_state).to(haf.device, haf.dtype)
         elif detector == 'threshold':
             final_state_double = torch.cat([final_state, final_state])
             sub_mat = sub_matrix(matrix, final_state_double, final_state_double)
@@ -1902,7 +1886,7 @@ class QumodeCircuit(Operation):
         ``p`` is the parity, corresponding to an even or odd cat state when ``p=0`` or ``p=1`` respectively.
         """
         if self._bosonic_states is None:
-            self._bosonic_states = [BosonicState(state='vac', nmode=1, cutoff=self.cutoff)] * self.nmode
+            self._bosonic_states = nn.ModuleList([BosonicState(state='vac', nmode=1, cutoff=self.cutoff)] * self.nmode)
         cat = CatState(r=r, theta=theta, p=p, cutoff=self.cutoff)
         self._bosonic_states[wires] = cat
 
@@ -1916,7 +1900,7 @@ class QumodeCircuit(Operation):
         ``epsilon`` is the finite energy damping parameter.
         """
         if self._bosonic_states is None:
-            self._bosonic_states = [BosonicState(state='vac', nmode=1, cutoff=self.cutoff)] * self.nmode
+            self._bosonic_states = nn.ModuleList([BosonicState(state='vac', nmode=1, cutoff=self.cutoff)] * self.nmode)
         gkp = GKPState(theta=theta, phi=phi, amp_cutoff=amp_cutoff, epsilon=epsilon, cutoff=self.cutoff)
         self._bosonic_states[wires] = gkp
 

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -317,6 +317,19 @@ class QumodeCircuit(Operation):
             state = state.state
         elif not isinstance(state, torch.Tensor):
             state = FockState(state, self.nmode, self.cutoff, self.basis, self.den_mat).state
+        if not self.basis and isinstance(state, torch.Tensor) and state.device.type == 'mps':
+            max_mps_dim = 16
+            mps_dim = 2 * self.nmode + 1 if self.den_mat else self.nmode + 1
+            if mps_dim > max_mps_dim:
+                warnings.warn(
+                    f'Apple Silicon MPS limit ({max_mps_dim} dims) exceeded. Auto-falling back to CPU.',
+                    UserWarning,
+                    stacklevel=4,
+                )
+                self.cpu()
+                state = state.cpu()
+                if isinstance(data, torch.Tensor):
+                    data = data.cpu()
         # preprocessing of batched initial states
         if self.basis:
             self._is_batch_expanded = False  # reset

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -353,7 +353,7 @@ class BeamSplitter(DoubleGate):
 
         See https://arxiv.org/pdf/2004.11002.pdf Eq.(74) and Eq.(75)
         """
-        sqrt = torch.sqrt(torch.arange(self.cutoff, dtype=torch.double, device=matrix.device))
+        sqrt = torch.sqrt(torch.arange(self.cutoff, dtype=matrix.real.dtype, device=matrix.device))
         tran_mat = matrix.new_zeros([self.cutoff] * 4)
         tran_mat[0, 0, 0, 0] = 1.0
         # rank 3
@@ -950,7 +950,7 @@ class UAnyGate(Gate):
         See https://arxiv.org/pdf/2004.11002.pdf Eq.(71)
         """
         nt = len(self.wires)
-        sqrt = torch.sqrt(torch.arange(self.cutoff, dtype=torch.double, device=matrix.device))
+        sqrt = torch.sqrt(torch.arange(self.cutoff, dtype=matrix.real.dtype, device=matrix.device))
         tran_mat = matrix.new_zeros([self.cutoff] * 2 * nt)
         tran_mat[tuple([0] * 2 * nt)] = 1.0
         for rank in range(nt + 1, 2 * nt + 1):

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -10,6 +10,7 @@ from torch import nn
 import deepquantum.photonic as dqp
 
 from ..qmath import is_unitary
+from ..utils import apply_complex_fix
 from .operation import Delay, Gate
 from .qmath import ladder_ops
 
@@ -607,7 +608,7 @@ class BeamSplitterTheta(BeamSplitter):
         noise = self.noise
         self.noise = False
         theta, phi = self.inputs_to_tensor([inputs, torch.pi / 2])
-        phi = phi.to(theta.dtype).to(theta.device)
+        phi = phi.to(theta.device, theta.dtype)
         self.noise = noise
         if self.requires_grad:
             self.theta = nn.Parameter(theta)
@@ -705,7 +706,7 @@ class BeamSplitterPhi(BeamSplitter):
         noise = self.noise
         self.noise = False
         theta, phi = self.inputs_to_tensor([torch.pi / 4, inputs])
-        theta = theta.to(phi.dtype).to(phi.device)
+        theta = theta.to(phi.device, phi.dtype)
         self.noise = noise
         if self.requires_grad:
             self.phi = nn.Parameter(phi)
@@ -925,18 +926,22 @@ class UAnyGate(Gate):
         self.register_buffer('matrix', unitary)
         self.register_buffer('matrix_state', None)
 
-    def to(self, arg: Any) -> 'UAnyGate':
-        """Set dtype or device of the ``UAnyGate``."""
-        if arg == torch.float:
-            self.matrix = self.matrix.to(torch.cfloat)
-            if self.matrix_state is not None:
-                self.matrix_state = self.matrix_state.to(torch.cfloat)
-        elif arg == torch.double:
-            self.matrix = self.matrix.to(torch.cdouble)
-            if self.matrix_state is not None:
-                self.matrix_state = self.matrix_state.to(torch.cdouble)
-        else:
-            super().to(arg)
+    def _apply(self, fn: Any) -> 'UAnyGate':
+        tensors_dict = {}
+        none_dict = {}
+        names = ['matrix', 'matrix_state']
+        for name in names:
+            tensor = self._buffers.pop(name)
+            if tensor is None:
+                none_dict[name] = tensor
+            else:
+                tensors_dict[name] = tensor
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
+        for key, value in none_dict.items():
+            self.register_buffer(key, value)
         return self
 
     def get_matrix_state(self, matrix: torch.Tensor) -> torch.Tensor:
@@ -1570,7 +1575,7 @@ class DisplacementPosition(Displacement):
         noise = self.noise
         self.noise = False
         r, theta = self.inputs_to_tensor([inputs, 0])
-        theta = theta.to(r.dtype).to(r.device)
+        theta = theta.to(r.device, r.dtype)
         self.noise = noise
         if self.requires_grad:
             self.r = nn.Parameter(r)
@@ -1655,7 +1660,7 @@ class DisplacementMomentum(Displacement):
         noise = self.noise
         self.noise = False
         r, theta = self.inputs_to_tensor([inputs, torch.pi / 2])
-        theta = theta.to(r.dtype).to(r.device)
+        theta = theta.to(r.device, r.dtype)
         self.noise = noise
         if self.requires_grad:
             self.r = nn.Parameter(r)

--- a/src/deepquantum/photonic/gate.py
+++ b/src/deepquantum/photonic/gate.py
@@ -336,8 +336,8 @@ class BeamSplitter(DoubleGate):
         """Get the local unitary matrix acting on creation operators."""
         # correspond to: U a^+ U^+ = u^T @ a^+
         theta, phi = self.inputs_to_tensor([theta, phi])
-        cos = torch.cos(theta)
-        sin = torch.sin(theta)
+        cos = torch.cos(theta) + 0j
+        sin = torch.sin(theta) + 0j
         e_m_ip = torch.exp(-1j * phi)
         e_ip = torch.exp(1j * phi)
         return torch.stack([cos, -e_m_ip * sin, e_ip * sin, cos]).reshape(2, 2)
@@ -511,8 +511,8 @@ class MZI(BeamSplitter):
         """Get the local unitary matrix acting on creation operators."""
         # correspond to: U a^+ U^+ = u^T @ a^+
         theta, phi = self.inputs_to_tensor([theta, phi])
-        cos = torch.cos(theta / 2)
-        sin = torch.sin(theta / 2)
+        cos = torch.cos(theta / 2) + 0j
+        sin = torch.sin(theta / 2) + 0j
         e_it = torch.exp(1j * theta / 2)
         e_ip = torch.exp(1j * phi)
         mat = 1j * e_it * torch.stack([e_ip * sin, cos, e_ip * cos, -sin]).reshape(2, 2)
@@ -1086,8 +1086,8 @@ class Squeezing(SingleGate):
         """Get the local symplectic matrix acting on annihilation and creation operators."""
         # correspond to: U^+ (a a^+) U = s @ (a a^+)
         r, theta = self.inputs_to_tensor([r, theta])
-        ch = torch.cosh(r)
-        sh = torch.sinh(r)
+        ch = torch.cosh(r) + 0j
+        sh = torch.sinh(r) + 0j
         e_it = torch.exp(1j * theta)
         e_m_it = torch.exp(-1j * theta)
         return torch.stack([ch, -e_it * sh, -e_m_it * sh, ch]).reshape(2, 2)
@@ -2146,8 +2146,8 @@ class ControlledZ(DoubleGate):
         """Get the local symplectic matrix acting on annihilation and creation operators."""
         # correspond to: U^+ (a a^+) U = s @ (a a^+)
         s = self.inputs_to_tensor(s).reshape(-1)
-        one = s.new_ones(1)
-        zero = s.new_zeros(1)
+        one = s.new_ones(1) + 0j
+        zero = s.new_zeros(1) + 0j
         x = 1j * s / 2
         mat = torch.stack([one, x, zero, x, x, one, x, zero, zero, -x, one, -x, -x, zero, -x, one]).reshape(4, 4)
         return mat

--- a/src/deepquantum/photonic/measurement.py
+++ b/src/deepquantum/photonic/measurement.py
@@ -214,8 +214,9 @@ class Homodyne(Generaldyne):
         vac_state[0] = 1
         inf_sqz_vac = torch.zeros_like(vac_state)  # (cutoff)
         orders = torch.arange(np.ceil(self.cutoff / 2), dtype=x.real.dtype, device=x.device)
-        fac_2n = torch.tensor(factorial(2 * orders), dtype=orders.dtype, device=orders.device)
-        fac_n = torch.tensor(factorial(orders), dtype=orders.dtype, device=orders.device)
+        orders_cpu = orders.cpu()
+        fac_2n = torch.tensor(factorial(2 * orders_cpu), dtype=orders.dtype, device=orders.device)
+        fac_n = torch.tensor(factorial(orders_cpu), dtype=orders.dtype, device=orders.device)
         inf_sqz_vac[::2] = (-0.5) ** orders * fac_2n**0.5 / fac_n  # unnormalized
         alpha = self.samples * dqp.kappa / dqp.hbar**0.5
         d = Displacement(cutoff=self.cutoff)

--- a/src/deepquantum/photonic/operation.py
+++ b/src/deepquantum/photonic/operation.py
@@ -386,12 +386,6 @@ class Delay(Operation):
         self.ntau = ntau
         self.gates = nn.Sequential()
 
-    def to(self, arg: Any) -> 'Delay':
-        """Set dtype or device of the ``Delay``."""
-        for gate in self.gates:
-            gate.to(arg)
-        return self
-
     def init_para(self, inputs: Any = None) -> None:
         """Initialize the parameters."""
         count = 0

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -135,7 +135,9 @@ def permanent_ryser(mat: torch.Tensor) -> torch.Tensor:
 
 def product_factorial(state: torch.Tensor) -> torch.Tensor:
     """Get the product of the factorial from the Fock state, i.e., :math:`|s_1,s_2,...s_n> -> s_1!s_2!...s_n!`."""
-    return torch.exp(torch.lgamma(state.double() + 1).sum(-1, keepdim=True))  # nature log gamma function
+    state = state + 0.0
+    # nature log gamma function
+    return torch.exp(torch.lgamma(state.cpu().double() + 1).sum(-1, keepdim=True)).to(state.device, state.dtype)
 
 
 def fock_combinations(nmode: int, nphoton: int, cutoff: int | None = None, nancilla: int = 0) -> list:

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -542,7 +542,8 @@ def sample_homodyne_fock(
     xs = torch.linspace(-x_range, x_range, nbin, dtype=state.real.dtype, device=state.device)  # (nbin)
     h_vals = torch.special.hermite_polynomial_h(coef**0.5 * xs, orders)  # （cutoff, nbin)
     # H_n / \sqrt{2^n * n!}
-    h_vals = h_vals / torch.sqrt(2**orders * torch.exp(torch.lgamma(orders.double() + 1))).to(orders.dtype)
+    factorial = torch.exp(torch.lgamma(orders.cpu().double() + 1)).to(orders.device, orders.dtype)
+    h_vals = h_vals / torch.sqrt(2**orders * factorial)
     h_mat = h_vals.reshape(1, cutoff, nbin) * h_vals.reshape(cutoff, 1, nbin)  # (cutoff, cutoff, nbin)
     h_terms = reduced_dm.unsqueeze(-1) * h_mat  # (batch, cutoff, cutoff, nbin)
     probs = (h_terms.sum(dim=[-3, -2]) * torch.exp(-coef * xs**2)).real  # (batch, nbin)

--- a/src/deepquantum/photonic/qmath.py
+++ b/src/deepquantum/photonic/qmath.py
@@ -313,7 +313,7 @@ def photon_number_mean_var_fock(
     """Get the expectation value and variance of the photon number for Fock state tensors."""
     if den_mat:
         rho = state.reshape(-1, cutoff**nmode, cutoff**nmode)
-        prob = torch.diagonal(rho, dim1=1, dim2=2).reshape([-1] + [cutoff] * nmode)
+        prob = torch.diagonal(rho, dim1=1, dim2=2).reshape([-1] + [cutoff] * nmode).real
     else:
         if state.ndim == nmode:
             state = state.unsqueeze(0)
@@ -328,7 +328,7 @@ def photon_number_mean_var_fock(
         var = num2_exp - num_exp**2
         num_exp_list.append(num_exp)
         var_list.append(var)
-    return torch.stack(num_exp_list).real, torch.stack(var_list).real
+    return torch.stack(num_exp_list), torch.stack(var_list)
 
 
 def quadrature_mean_fock(

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -395,7 +395,7 @@ class BosonicState(nn.Module):
         if plot:
             plt.subplots(1, 1, figsize=(12, 10))
             plt.xlabel('Quadrature q')
-            plt.ylabel('Wave_function')
+            plt.ylabel('Wave function')
             plt.plot(xvec.cpu(), marginal_vals[k].cpu())
             plt.show()
         return marginal_vals
@@ -434,8 +434,8 @@ class CatState(BosonicState):
         means = (
             torch.stack(
                 [
-                    torch.stack([real_part, imag_part]),
-                    -torch.stack([real_part, imag_part]),
+                    torch.stack([real_part, imag_part]) + 0j,
+                    -torch.stack([real_part, imag_part]) + 0j,
                     torch.stack([imag_part, -real_part]) * 1j,
                     -torch.stack([imag_part, -real_part]) * 1j,
                 ]
@@ -444,7 +444,7 @@ class CatState(BosonicState):
             / dqp.kappa
         )
         temp = torch.exp(-2 * r**2)
-        w0 = 0.5 / (1 + temp * torch.cos(p * torch.pi))
+        w0 = 0.5 / (1 + temp * torch.cos(p * torch.pi)) + 0j
         w1 = w0
         w2 = torch.exp(-1j * torch.pi * p) * temp * w0
         w3 = torch.exp(1j * torch.pi * p) * temp * w0

--- a/src/deepquantum/photonic/state.py
+++ b/src/deepquantum/photonic/state.py
@@ -12,6 +12,7 @@ import deepquantum.photonic as dqp
 
 from ..communication import comm_get_rank, comm_get_world_size
 from ..qmath import is_power, list_to_decimal, multi_kron
+from ..utils import apply_complex_fix
 from .qmath import cv_to_wigner, dirac_ket, fock_to_wigner, xpxp_to_xxpp, xxpp_to_xpxp
 
 
@@ -102,16 +103,19 @@ class FockState(nn.Module):
             assert all(i == self.cutoff for i in state_ts.shape[1:])
         self.register_buffer('state', state_ts)
 
-    def to(self, arg: Any) -> 'FockState':
-        """Set dtype or device of the ``FockState``."""
-        if arg == torch.float:
-            if not self.basis:
-                self.state = self.state.to(torch.cfloat)
-        elif arg == torch.double:
-            if not self.basis:
-                self.state = self.state.to(torch.cdouble)
+    def _apply(self, fn: Any) -> 'FockState':
+        if self.basis:
+            super()._apply(fn)
         else:
-            self.state = self.state.to(arg)
+            tensors_dict = {}
+            name = 'state'
+            tensor = self._buffers.pop(name)
+            if tensor is not None:
+                tensors_dict[name] = tensor
+            super()._apply(fn)
+            corrected = apply_complex_fix(fn, tensors_dict)
+            for key, value in corrected.items():
+                self.register_buffer(key, value)
         return self
 
     def wigner(
@@ -318,20 +322,14 @@ class BosonicState(nn.Module):
             cutoff = 5
         self.cutoff = cutoff
 
-    def to(self, arg: Any) -> 'BosonicState':
-        """Set dtype or device of the ``BosonicState``."""
-        if arg == torch.float:
-            self.cov = self.cov.to(arg)
-            self.mean = self.mean.to(torch.cfloat)
-            self.weight = self.weight.to(torch.cfloat)
-        elif arg == torch.double:
-            self.cov = self.cov.to(arg)
-            self.mean = self.mean.to(torch.cdouble)
-            self.weight = self.weight.to(torch.cdouble)
-        else:
-            self.cov = self.cov.to(arg)
-            self.mean = self.mean.to(arg)
-            self.weight = self.weight.to(arg)
+    def _apply(self, fn: Any) -> 'BosonicState':
+        tensors_dict = {}
+        names = ['mean', 'weight']
+        tensors_dict = {name: tensor for name in names if (tensor := self._buffers.pop(name)) is not None}
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     def tensor_product(self, state: 'BosonicState') -> 'BosonicState':
@@ -386,7 +384,7 @@ class BosonicState(nn.Module):
         cov = self.cov[..., idx[:, None], idx]
         mean = self.mean[..., idx, :]
         r = PhaseShift(inputs=-phi, nmode=1, wires=[0], cutoff=self.cutoff)
-        r.to(cov.dtype).to(cov.device)
+        r.to(cov.device, cov.dtype)
         cov, mean = r([cov, mean])  # (batch, ncomb, 2, 2)
         cov = cov[..., 0, 0].unsqueeze(1)
         mean = mean[..., 0, 0].unsqueeze(1)
@@ -654,17 +652,14 @@ class DistributedFockState(nn.Module):
         self.register_buffer('buffer', buffer)
         self.reset()
 
-    def to(self, arg: Any) -> 'DistributedFockState':
-        """Set dtype or device of the DistributedFockState."""
-        if arg == torch.float:
-            self.amps = self.amps.to(torch.cfloat)
-            self.buffer = self.buffer.to(torch.cfloat)
-        elif arg == torch.double:
-            self.amps = self.amps.to(torch.cdouble)
-            self.buffer = self.buffer.to(torch.cdouble)
-        else:
-            self.amps = self.amps.to(arg)
-            self.buffer = self.buffer.to(arg)
+    def _apply(self, fn: Any) -> 'DistributedFockState':
+        tensors_dict = {}
+        names = ['amps', 'buffer']
+        tensors_dict = {name: tensor for name in names if (tensor := self._buffers.pop(name)) is not None}
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     def reset(self):

--- a/src/deepquantum/photonic/utils.py
+++ b/src/deepquantum/photonic/utils.py
@@ -53,10 +53,14 @@ def mem_to_chunksize(device: torch.device, dtype: torch.dtype) -> int | None:
     """
     if (device, dtype) in dqp.perm_chunksize_dict:
         return dqp.perm_chunksize_dict[device, dtype]
-    if device == torch.device('cpu'):
+    if device.type == 'cpu':
         mem_free_gb = psutil.virtual_memory().free / 1024**3
-    else:
+    elif device.type == 'cuda':
         mem_free_gb = torch.cuda.mem_get_info(device=device)[0] / 1024**3
+    elif device.type == 'mps':
+        mem_free_gb = torch.mps.recommended_max_memory() / 1024**3
+    else:
+        raise ValueError(f'Unknown device type: {device.type}')
     if dtype == torch.cfloat:
         if mem_free_gb > 80:
             # requires checking when we have such GPUs:)

--- a/src/deepquantum/qmath.py
+++ b/src/deepquantum/qmath.py
@@ -713,7 +713,7 @@ def get_prob_mps(mps_lst: list[torch.Tensor], wire: int) -> torch.Tensor:
             torch.Tensor: Contracted tensor
         """
         if not tensors:  # Handle empty tensor list case
-            return torch.tensor(1).reshape(1, 1, 1, 1).to(mps_lst[0].dtype).to(mps_lst[0].device)
+            return torch.tensor(1).reshape(1, 1, 1, 1).to(mps_lst[0].device, mps_lst[0].dtype)
 
         # Contract first tensor with its conjugate
         contracted = torch.tensordot(tensors[0].conj(), tensors[0], dims=([1], [1]))

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -26,7 +26,7 @@ class SingleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: list[tuple[nn.Sequential, ...]],
+        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,
@@ -72,7 +72,7 @@ class DoubleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: list[tuple[nn.Sequential, ...]],
+        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,
@@ -99,11 +99,11 @@ class DoubleGateQPD(GateQPD):
 
     def decompose(self) -> tuple[SingleGateQPD, SingleGateQPD]:
         """Decompose the gate into two single-qubit QPD gates."""
-        bases1 = []
-        bases2 = []
+        bases1 = nn.ModuleList([])
+        bases2 = nn.ModuleList([])
         for basis in self.bases:
-            bases1.append(tuple([basis[0]]))
-            bases2.append(tuple([basis[1]]))
+            bases1.append(nn.ModuleList([basis[0]]))
+            bases2.append(nn.ModuleList([basis[1]]))
         name = self.name + f'_label{self.label}_'
         gate1 = SingleGateQPD(
             bases1, self.coeffs, self.label, name + '1', self.nqubit, [self.wires[0]], self.den_mat, self.tsr_mode
@@ -157,16 +157,18 @@ class MoveQPD(DoubleGateQPD):
         prep_iplus = nn.Sequential(h2, s2)
         prep_iminus = nn.Sequential(x2, h2, s2)
 
-        bases = [
-            (measure_i, prep_0),
-            (measure_i, prep_1),
-            (measure_x, prep_plus),
-            (measure_x, prep_minus),
-            (measure_y, prep_iplus),
-            (measure_y, prep_iminus),
-            (measure_z, prep_0),
-            (measure_z, prep_1),
-        ]
+        bases = nn.ModuleList(
+            [
+                nn.ModuleList([measure_i, prep_0]),
+                nn.ModuleList([measure_i, prep_1]),
+                nn.ModuleList([measure_x, prep_plus]),
+                nn.ModuleList([measure_x, prep_minus]),
+                nn.ModuleList([measure_y, prep_iplus]),
+                nn.ModuleList([measure_y, prep_iminus]),
+                nn.ModuleList([measure_z, prep_0]),
+                nn.ModuleList([measure_z, prep_1]),
+            ]
+        )
         coeffs = [0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5]
         super().__init__(
             bases=bases,

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -26,7 +26,7 @@ class SingleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
+        bases: nn.ModuleList,
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,
@@ -72,7 +72,7 @@ class DoubleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: nn.ModuleList[nn.ModuleList[nn.Sequential, ...]],
+        bases: nn.ModuleList,
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,

--- a/src/deepquantum/qpd.py
+++ b/src/deepquantum/qpd.py
@@ -26,7 +26,7 @@ class SingleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: nn.ModuleList,
+        bases: 'nn.ModuleList[nn.ModuleList[nn.Sequential]]',
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,
@@ -72,7 +72,7 @@ class DoubleGateQPD(GateQPD):
 
     def __init__(
         self,
-        bases: nn.ModuleList,
+        bases: 'nn.ModuleList[nn.ModuleList[nn.Sequential]]',
         coeffs: list[float],
         label: int | None = None,
         name: str | None = None,

--- a/src/deepquantum/state.py
+++ b/src/deepquantum/state.py
@@ -8,6 +8,7 @@ from torch import nn
 from .bitmath import is_power_of_2, log_base2, power_of_2
 from .communication import comm_get_rank, comm_get_world_size
 from .qmath import amplitude_encoding, inner_product_mps, is_density_matrix, qr, svd
+from .utils import apply_complex_fix
 
 
 class QubitState(nn.Module):
@@ -59,14 +60,16 @@ class QubitState(nn.Module):
                     state = state @ state.mH
                 self.register_buffer('state', state)
 
-    def to(self, arg: Any) -> 'QubitState':
-        """Set dtype or device of the ``QubitState``."""
-        if arg == torch.float:
-            self.state = self.state.to(torch.cfloat)
-        elif arg == torch.double:
-            self.state = self.state.to(torch.cdouble)
-        else:
-            self.state = self.state.to(arg)
+    def _apply(self, fn: Any) -> 'QubitState':
+        tensors_dict = {}
+        name = 'state'
+        tensor = self._buffers.pop(name)
+        if tensor is not None:
+            tensors_dict[name] = tensor
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     def forward(self) -> None:
@@ -111,16 +114,14 @@ class MatrixProductState(nn.Module):
         self.center = -1
         self.set_tensors(state)
 
-    def to(self, arg: Any) -> 'MatrixProductState':
-        """Set dtype or device of the ``MatrixProductState``."""
-        tensors = self.tensors
-        for i in range(self.nsite):
-            if arg == torch.float:
-                self._buffers[f'tensor{i}'] = tensors[i].to(torch.cfloat)
-            elif arg == torch.double:
-                self._buffers[f'tensor{i}'] = tensors[i].to(torch.cdouble)
-            else:
-                self._buffers[f'tensor{i}'] = tensors[i].to(arg)
+    def _apply(self, fn: Any) -> 'MatrixProductState':
+        tensors_dict = {
+            name: tensor for i in range(self.nsite) if (tensor := self._buffers.pop(name := f'tensor{i}')) is not None
+        }
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     @property
@@ -363,17 +364,14 @@ class DistributedQubitState(nn.Module):
         self.register_buffer('buffer', buffer)
         self.reset()
 
-    def to(self, arg: Any) -> 'DistributedQubitState':
-        """Set dtype or device of the ``DistributedQubitState``."""
-        if arg == torch.float:
-            self.amps = self.amps.to(torch.cfloat)
-            self.buffer = self.buffer.to(torch.cfloat)
-        elif arg == torch.double:
-            self.amps = self.amps.to(torch.cdouble)
-            self.buffer = self.buffer.to(torch.cdouble)
-        else:
-            self.amps = self.amps.to(arg)
-            self.buffer = self.buffer.to(arg)
+    def _apply(self, fn: Any) -> 'DistributedQubitState':
+        tensors_dict = {}
+        names = ['amps', 'buffer']
+        tensors_dict = {name: tensor for name in names if (tensor := self._buffers.pop(name)) is not None}
+        super()._apply(fn)
+        corrected = apply_complex_fix(fn, tensors_dict)
+        for key, value in corrected.items():
+            self.register_buffer(key, value)
         return self
 
     def reset(self):

--- a/src/deepquantum/utils.py
+++ b/src/deepquantum/utils.py
@@ -3,6 +3,11 @@
 import time
 from collections.abc import Callable
 from functools import wraps
+from typing import Any
+
+import torch
+
+import deepquantum as dq
 
 
 def record_time(func: Callable) -> Callable:
@@ -35,3 +40,11 @@ class Time:
             return rst
 
         return wrapped_function
+
+
+def apply_complex_fix(fn: Any, tensors_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Apply the function to the tensors in the dictionary and convert the result to complex dtype."""
+    first_tensor = next(iter(tensors_dict.values()))
+    probe = fn(torch.empty(0, dtype=first_tensor.real.dtype, device=first_tensor.device))
+    target_dtype = dq.dtype_map.get(probe.dtype, probe.dtype)
+    return {name: tensor.to(probe.device, target_dtype) for name, tensor in tensors_dict.items()}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,41 @@
+import torch
+from torch import nn
+
+import deepquantum as dq
+
+
+def test_module_to_func():
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cir_qubit = dq.QubitCircuit(1)
+            self.cir_qubit.h(0)
+            self.cir_qubit.hamiltonian([[1, 'x0'], [1, 'y0'], [1, 'z0']], encode=True)
+            self.cir_qubit.observable(0)
+            self.cir_mps = dq.QubitCircuit(1, mps=True)
+            self.cir_mps.h(0)
+            self.cir_mps.hamiltonian([[1, 'x0'], [1, 'y0'], [1, 'z0']], encode=True)
+            self.cir_fock = dq.QumodeCircuit(2, 'vac', cutoff=2, backend='fock', basis=False)
+            self.cir_fock.ps(0, encode=True)
+            self.cir_fock.bs([0, 1], encode=True)
+            self.cir_bosonic = dq.QumodeCircuit(1, 'vac', backend='bosonic')
+            self.cir_bosonic.cat(0)
+            self.pattern = dq.Pattern()
+            self.pattern.n([0, 1])
+            self.pattern.e(0, 1)
+            self.pattern.m(0, encode=True)
+            self.pattern.x(1)
+
+    model = Model()
+    model.double()
+    for buffer in model.buffers():
+        assert buffer.dtype in (torch.double, torch.cdouble)
+    if torch.cuda.is_available():
+        model.to('cuda')
+        for buffer in model.buffers():
+            assert buffer.device.type == 'cuda'
+    if torch.mps.is_available():
+        model.float()
+        model.to('mps')
+        for buffer in model.buffers():
+            assert buffer.device.type == 'mps'


### PR DESCRIPTION
## Description
This PR resolves the Apple Silicon MPS backend issues reported in #149 , and significantly refactors the internal device/dtype casting mechanism to align with PyTorch's native behaviors.

## Key Changes

### 1. Fix Apple Silicon MPS Compatibility
* **Resolve Parametric Gates Stacking:** Explicitly cast tensors to complex dtype before `torch.stack` in parametric gates (e.g., `Rx`). This fixes the `cat_int32_t_float_float2` RuntimeError on the MPS backend.
* **Auto-fallback to CPU for >16 dimensions:** Add a guard in the forward pass. If the state tensor exceeds the 16-dimension limit, it throws a clear warning and automatically falls back to CPU.

### 2. Refactor PyTorch Native Casting
* **Replace Custom `.to()` with `._apply()`:** Transition all custom `nn.Module`s from overriding `.to()` to using `._apply()` to enable robust, native recursive graph traversal.
* **Implement Unified Complex Probing:** Add `apply_complex_fix` inside `._apply()` to safely map floating-point actions to their complex counterparts during device/dtype transitions.

## Limitations & Known Issues
* **Gaussian Backend MPS Support:** Due to current limitations in PyTorch's MPS backend, `torch.linalg.det()` for complex-valued matrices is not yet supported, resulting in `RuntimeError: linalg.lu_factor(): MPS doesn't support complex types.`