### PR TITLE
Add Gaussian TDM substates and batched probabilities

### DIFF
--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -791,6 +791,100 @@ class QumodeCircuit(Operation):
         ).reshape(nstep - 1, self.nmode)
         return torch.cat([first.unsqueeze(0), later], dim=0)
 
+    def tdm_substate(
+        self,
+        nstep: int,
+        time_steps: int | slice | list[int] | torch.Tensor,
+        wires: int | list[int] | torch.Tensor | None = None,
+    ) -> list[torch.Tensor]:
+        """Get the Gaussian state of selected TDM outputs.
+
+        Args:
+            nstep: The number of time steps.
+            time_steps: The selected time steps in ascending order.
+            wires: The selected spatial wires. Default: ``None``
+
+        Returns:
+            The covariance matrix and mean vector in time-major order, with shapes
+            ``(1, 2 * nselected, 2 * nselected)`` and ``(1, 2 * nselected, 1)``.
+        """
+        assert self.backend == 'gaussian', 'tdm_substate() requires Gaussian backend'
+        assert self._with_delay, 'tdm_substate() requires at least one delay loop'
+        assert self.ndata == 0, 'tdm_substate() does not support encoded gates'
+        assert isinstance(nstep, int) and not isinstance(nstep, bool) and nstep > 0, 'nstep must be a positive integer'
+        if isinstance(time_steps, slice):
+            time_steps = torch.arange(nstep)[time_steps]
+        else:
+            time_steps = torch.as_tensor(time_steps, dtype=torch.long).reshape(-1)
+        assert time_steps.numel() > 0, 'time_steps must not be empty'
+        assert torch.all((time_steps >= 0) & (time_steps < nstep)), 'time_steps must lie in [0, nstep)'
+        assert time_steps.numel() == 1 or torch.all(time_steps[1:] > time_steps[:-1]), (
+            'time_steps must be unique and ascending'
+        )
+        wires = torch.arange(self.nmode) if wires is None else torch.as_tensor(wires, dtype=torch.long).reshape(-1)
+        assert wires.numel() > 0, 'wires must not be empty'
+        assert torch.all((wires >= 0) & (wires < self.nmode)), 'wires must lie in [0, nmode)'
+        assert torch.unique(wires).numel() == wires.numel(), 'wires must be unique'
+
+        self._prepare_unroll_dict()
+        loop_wires = []
+        for values in self._unroll_dict.values():
+            for value in values:
+                if isinstance(value, list):
+                    loop_wires.extend(value)
+        loop_index = {wire: index for index, wire in enumerate(loop_wires)}
+        nloop = len(loop_wires)
+        vac = self.init_state.cov.new_tensor(dqp.hbar / (4 * dqp.kappa**2))
+        cov = torch.eye(2 * nloop, dtype=vac.dtype, device=vac.device) * vac
+        mean = torch.zeros(2 * nloop, 1, dtype=vac.dtype, device=vac.device)
+        selected_steps = set(time_steps.tolist())
+        selected_wires = wires.tolist()
+        nretained = 0
+
+        for step in range(nstep):
+            old_nmode = nloop + nretained
+            step_nmode = old_nmode + self.nmode
+            old_idx = torch.cat(
+                [torch.arange(old_nmode, device=cov.device), torch.arange(old_nmode, device=cov.device) + step_nmode]
+            )
+            cov_step = torch.eye(2 * step_nmode, dtype=cov.dtype, device=cov.device) * vac
+            cov_step = cov_step.index_put((old_idx[:, None], old_idx), cov)
+            mean_step = torch.zeros(2 * step_nmode, 1, dtype=mean.dtype, device=mean.device)
+            mean_step = mean_step.index_copy(0, old_idx, mean)
+
+            ndelay = np.array([0] * self.nmode)
+            for op in self.operators:
+                if isinstance(op, Barrier):
+                    continue
+                if isinstance(op, Delay):
+                    wire = op.wires[0]
+                    ndelay[wire] += 1
+                    delay_wires = self._unroll_dict[wire][-ndelay[wire] - 1]
+                    wire1 = loop_index[delay_wires[step % op.ntau]]
+                    wire2 = old_nmode + wire
+                    gates = [(op.gates[0], [wire1, wire2])]
+                    gates.extend((gate, [wire1]) for gate in op.gates[1:])
+                else:
+                    gates = [(op, [old_nmode + wire for wire in op.wires])]
+                for gate, gate_wires in gates:
+                    gate_step = copy(gate)
+                    gate_step.nmode = step_nmode
+                    gate_step.wires = gate_wires
+                    cov_step, mean_step = gate_step([cov_step, mean_step])
+
+            keep = list(range(old_nmode))
+            if step in selected_steps:
+                keep.extend(old_nmode + wire for wire in selected_wires)
+                nretained += len(selected_wires)
+            keep = torch.tensor(keep, dtype=torch.long, device=cov.device)
+            keep_xp = torch.cat([keep, keep + step_nmode])
+            cov = cov_step[keep_xp[:, None], keep_xp]
+            mean = mean_step[keep_xp]
+
+        retained = torch.arange(nloop, nloop + nretained, device=cov.device)
+        retained_xp = torch.cat([retained, retained + nloop + nretained])
+        return [cov[retained_xp[:, None], retained_xp].unsqueeze(0), mean[retained_xp].unsqueeze(0)]
+
     def global_circuit(self, nstep: int, use_deepcopy: bool = False) -> 'QumodeCircuit':
         """Get the global circuit given the number of time steps.
 
@@ -1238,20 +1332,18 @@ class QumodeCircuit(Operation):
         values = []
         positions = []
         nmode = final_states.shape[-1]
-        size = matrix.shape[-1]
         for clicks, group_positions in groups.items():
             position = torch.tensor(group_positions, dtype=torch.long, device=final_states.device)
-            if len(group_positions) == 1:
-                value = kensingtonian(matrix, final_states[position[0]], num_detectors, gamma).reshape(1)
+            reduced_clicks = tuple(click for click in clicks if click > 0)
+            if not reduced_clicks:
+                value = matrix.new_ones(len(group_positions))
             else:
-                # Reorder the group to share one canonical term-data batch.
                 orders = final_states.index_select(0, position).argsort(dim=-1)
-                indices = torch.cat([orders, orders + nmode], dim=-1)
-                matrices = matrix.expand(len(group_positions), -1, -1)
-                matrices = matrices.gather(1, indices.unsqueeze(-1).expand(-1, -1, size))
-                matrices = matrices.gather(2, indices.unsqueeze(1).expand(-1, size, -1))
-                gammas = None if gamma is None else gamma.expand(len(group_positions), -1).gather(1, indices)
-                canonical_clicks = final_states.new_tensor(clicks)
+                clicked_modes = orders[:, -len(reduced_clicks) :]
+                indices = torch.cat([clicked_modes, clicked_modes + nmode], dim=-1)
+                matrices = matrix[indices.unsqueeze(-1), indices.unsqueeze(-2)]
+                gammas = None if gamma is None else gamma[indices]
+                canonical_clicks = final_states.new_tensor(reduced_clicks)
                 value = kensingtonian(matrices, canonical_clicks, num_detectors, gammas)
             values.append(value)
             positions.append(position)

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -796,6 +796,7 @@ class QumodeCircuit(Operation):
         nstep: int,
         time_steps: int | slice | list[int] | torch.Tensor,
         wires: int | list[int] | torch.Tensor | None = None,
+        data: torch.Tensor | None = None,
     ) -> list[torch.Tensor]:
         """Get the Gaussian state of selected TDM outputs.
 
@@ -803,14 +804,15 @@ class QumodeCircuit(Operation):
             nstep: The number of time steps.
             time_steps: The selected time steps in ascending order.
             wires: The selected spatial wires. Default: ``None``
+            data: Time-major encoded data with shape ``(nstep * ndata,)`` or
+                ``(batch, nstep * ndata)``. Default: ``None``
 
         Returns:
             The covariance matrix and mean vector in time-major order, with shapes
-            ``(1, 2 * nselected, 2 * nselected)`` and ``(1, 2 * nselected, 1)``.
+            ``(batch, 2 * nselected, 2 * nselected)`` and ``(batch, 2 * nselected, 1)``.
         """
         assert self.backend == 'gaussian', 'tdm_substate() requires Gaussian backend'
         assert self._with_delay, 'tdm_substate() requires at least one delay loop'
-        assert self.ndata == 0, 'tdm_substate() does not support encoded gates'
         assert isinstance(nstep, int) and not isinstance(nstep, bool) and nstep > 0, 'nstep must be a positive integer'
         if isinstance(time_steps, slice):
             time_steps = torch.arange(nstep)[time_steps]
@@ -826,6 +828,29 @@ class QumodeCircuit(Operation):
         assert torch.all((wires >= 0) & (wires < self.nmode)), 'wires must lie in [0, nmode)'
         assert torch.unique(wires).numel() == wires.numel(), 'wires must be unique'
 
+        if self.ndata == 0:
+            assert data is None, 'data must be None when the circuit has no encoders'
+            states = [self._tdm_substate_gaussian(nstep, time_steps, wires)]
+        else:
+            assert isinstance(data, torch.Tensor), 'data is required when the circuit has encoders'
+            if data.ndim == 1:
+                data = data.unsqueeze(0)
+            assert data.ndim == 2 and data.shape[1] == nstep * self.ndata, (
+                f'data must have shape ({nstep * self.ndata},) or (batch, {nstep * self.ndata})'
+            )
+            circuit = deepcopy(self)
+            states = [circuit._tdm_substate_gaussian(nstep, time_steps, wires, sample) for sample in data]
+        cov, mean = zip(*states, strict=True)
+        return [torch.stack(cov), torch.stack(mean)]
+
+    def _tdm_substate_gaussian(
+        self,
+        nstep: int,
+        time_steps: torch.Tensor,
+        wires: torch.Tensor,
+        data: torch.Tensor | None = None,
+    ) -> list[torch.Tensor]:
+        """Get one encoded Gaussian TDM substate."""
         self._prepare_unroll_dict()
         loop_wires = []
         for values in self._unroll_dict.values():
@@ -842,6 +867,8 @@ class QumodeCircuit(Operation):
         nretained = 0
 
         for step in range(nstep):
+            if data is not None:
+                self.encode(data[step * self.ndata : (step + 1) * self.ndata])
             old_nmode = nloop + nretained
             step_nmode = old_nmode + self.nmode
             old_idx = torch.cat(
@@ -883,7 +910,7 @@ class QumodeCircuit(Operation):
 
         retained = torch.arange(nloop, nloop + nretained, device=cov.device)
         retained_xp = torch.cat([retained, retained + nloop + nretained])
-        return [cov[retained_xp[:, None], retained_xp].unsqueeze(0), mean[retained_xp].unsqueeze(0)]
+        return [cov[retained_xp[:, None], retained_xp], mean[retained_xp]]
 
     def global_circuit(self, nstep: int, use_deepcopy: bool = False) -> 'QumodeCircuit':
         """Get the global circuit given the number of time steps.

--- a/src/deepquantum/photonic/circuit.py
+++ b/src/deepquantum/photonic/circuit.py
@@ -764,6 +764,33 @@ class QumodeCircuit(Operation):
                 op_m_tdm.wires = [self._unroll_dict[wire][-1] for wire in op_m.wires]
                 self._measurements_tdm.append(op_m_tdm)
 
+    def tdm_output_wires(self, nstep: int) -> torch.Tensor:
+        """Get output wires for each time step without building the global circuit.
+
+        Args:
+            nstep: The number of time steps.
+
+        Returns:
+            The output wires with shape ``(nstep, nmode)``.
+        """
+        if not self._with_delay:
+            raise ValueError('tdm_output_wires() requires at least one delay loop')
+        if not isinstance(nstep, int) or isinstance(nstep, bool) or nstep < 1:
+            raise ValueError('nstep must be a positive integer')
+        self._prepare_unroll_dict()
+        first = torch.tensor(
+            [self._unroll_dict[wire][-1] for wire in range(self.nmode)],
+            dtype=torch.long,
+        )
+        if nstep == 1:
+            return first.unsqueeze(0)
+        later = torch.arange(
+            self._nmode_tdm,
+            self._nmode_tdm + (nstep - 1) * self.nmode,
+            dtype=torch.long,
+        ).reshape(nstep - 1, self.nmode)
+        return torch.cat([first.unsqueeze(0), later], dim=0)
+
     def global_circuit(self, nstep: int, use_deepcopy: bool = False) -> 'QumodeCircuit':
         """Get the global circuit given the number of time steps.
 
@@ -1011,14 +1038,21 @@ class QumodeCircuit(Operation):
         """Get the probability of the final state related to the reference state.
 
         Args:
-            final_state: The final Fock basis state.
+            final_state: The final Fock basis state with shape ``(nmode,)``. For Gaussian backend,
+                multiple final states with shape ``(npattern, nmode)`` are also supported.
             refer_state: The initial Fock basis state or the final Gaussian state. Default: ``None``
             unitary: The unitary matrix. Default: ``None``
         """
         if not isinstance(final_state, torch.Tensor):
             final_state = torch.tensor(final_state, dtype=torch.long)
         result_name = 'clicks' if self.backend == 'gaussian' and self.detector == 'click' else 'photons'
-        assert max(final_state) < self.cutoff, f'The number of {result_name} must be less than cutoff'
+        assert final_state.numel() > 0, 'The final state must not be empty'
+        if self.backend == 'gaussian':
+            assert final_state.ndim in (1, 2), 'The final state must be 1D or 2D for Gaussian backend'
+        else:
+            assert final_state.ndim == 1, 'The final state must be 1D'
+        assert torch.all(final_state >= 0), f'The number of {result_name} must be non-negative'
+        assert final_state.max() < self.cutoff, f'The number of {result_name} must be less than cutoff'
         if self.backend == 'fock':
             if refer_state is None:
                 refer_state = self._prepare_init_state(self.init_state.state)
@@ -1084,9 +1118,17 @@ class QumodeCircuit(Operation):
         return prob
 
     def _get_prob_gaussian(self, final_state: Any, state: Any = None) -> torch.Tensor:
-        """Get the batched probabilities of the final state for Gaussian backend."""
+        """Get probabilities of one or multiple final states for Gaussian backend."""
         if not isinstance(final_state, torch.Tensor):
             final_state = torch.tensor(final_state, dtype=torch.long)
+        assert final_state.ndim in (1, 2)
+        is_single = final_state.ndim == 1
+        final_states = final_state.unsqueeze(0) if is_single else final_state
+        if self.detector in ('pnrd', 'threshold') and not is_single:
+            totals = final_states.sum(dim=-1)
+            assert torch.all(totals == totals[0]), (
+                'PNRD and threshold patterns in one batch must have the same total occupation'
+            )
         if state is None:
             cov = self._cov
             mean = self._mean
@@ -1103,9 +1145,14 @@ class QumodeCircuit(Operation):
         batch = cov.shape[0]
         probs = []
         for i in range(batch):
-            prob = self._get_probs_gaussian_helper(final_state, cov=cov[i], mean=mean[i], detector=self.detector)[0]
+            prob = self._get_probs_gaussian_helper(final_states, cov=cov[i], mean=mean[i], detector=self.detector)
             probs.append(prob)
-        return torch.stack(probs).squeeze()
+        probs = torch.stack(probs)
+        if batch == 1:
+            probs = probs[0]
+        if is_single:
+            probs = probs[..., 0]
+        return probs
 
     def _get_probs_gaussian_helper(
         self,

--- a/tests/test_photonic_batch_shape.py
+++ b/tests/test_photonic_batch_shape.py
@@ -62,6 +62,10 @@ def test_gaussian_get_prob_batch_shapes():
     torch.testing.assert_close(probs[-2], expected)
     torch.testing.assert_close(probs[-1], expected.expand(2, -1))
 
+    multiplexed = torch.tensor([[2, 0], [0, 2], [2, 1], [1, 2], [0, 0]])
+    expected = torch.stack([cir.get_prob(pattern, state) for pattern in multiplexed])
+    torch.testing.assert_close(cir.get_prob(multiplexed, state), expected)
+
 
 @pytest.mark.parametrize('detector', ['pnrd', 'threshold'])
 def test_gaussian_get_prob_fixed_total_pattern_batch(detector):

--- a/tests/test_photonic_batch_shape.py
+++ b/tests/test_photonic_batch_shape.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 import deepquantum as dq
@@ -36,6 +37,46 @@ def test_gaussian_batch_shape():
     assert tuple(state[0].shape) == (batch, 2, 2) and tuple(state[1].shape) == (batch, 2, 1)
     state = cir(data=data2)
     assert tuple(state[0].shape) == (batch, 2, 2) and tuple(state[1].shape) == (batch, 2, 1)
+
+
+def test_gaussian_get_prob_batch_shapes():
+    cir = dq.QumodeCircuit(2, 'vac', cutoff=3, backend='gaussian', detector='click')
+    cir.s(0, r=0.3)
+    cir.bs([0, 1], [0.4, 0.2])
+    cir.to(torch.double)
+    state = cir()
+    state_batch = [state[0].expand(2, -1, -1), state[1].expand(2, -1, -1)]
+    patterns = torch.tensor([[0, 0], [1, 0], [0, 1], [1, 1]])
+
+    probs = [
+        cir.get_prob(patterns[0], state),
+        cir.get_prob(patterns[0], state_batch),
+        cir.get_prob(patterns[:1], state),
+        cir.get_prob(patterns[:1], state_batch),
+        cir.get_prob(patterns, state),
+        cir.get_prob(patterns, state_batch),
+    ]
+    expected = torch.stack([cir.get_prob(pattern, state) for pattern in patterns])
+
+    assert [prob.shape for prob in probs] == [(), (2,), (1,), (2, 1), (4,), (2, 4)]
+    torch.testing.assert_close(probs[-2], expected)
+    torch.testing.assert_close(probs[-1], expected.expand(2, -1))
+
+
+@pytest.mark.parametrize('detector', ['pnrd', 'threshold'])
+def test_gaussian_get_prob_fixed_total_pattern_batch(detector):
+    cir = dq.QumodeCircuit(2, 'vac', cutoff=3, backend='gaussian', detector=detector)
+    cir.s(0, r=0.2)
+    cir.to(torch.double)
+    state = cir()
+    patterns = torch.tensor([[1, 0], [0, 1]])
+
+    batched = cir.get_prob(patterns, state)
+    expected = torch.stack([cir.get_prob(pattern, state) for pattern in patterns])
+
+    torch.testing.assert_close(batched, expected)
+    with pytest.raises(AssertionError, match='same total occupation'):
+        cir.get_prob(torch.tensor([[0, 0], [1, 0]]), state)
 
 
 def test_bosonic_shape():

--- a/tests/test_photonic_tdm.py
+++ b/tests/test_photonic_tdm.py
@@ -1,0 +1,13 @@
+import torch
+
+import deepquantum as dq
+
+
+def test_tdm_output_wires():
+    circuit = dq.QumodeCircuit(2, init_state='vac', backend='gaussian')
+    circuit.delay(0, ntau=2, inputs=[0.3, 0.1], convention='mzi')
+    circuit.delay(1, ntau=3, inputs=[0.4, -0.2], convention='mzi')
+
+    output_wires = circuit.tdm_output_wires(3)
+
+    assert torch.equal(output_wires, torch.tensor([[2, 6], [7, 8], [9, 10]]))

--- a/tests/test_photonic_tdm.py
+++ b/tests/test_photonic_tdm.py
@@ -34,3 +34,36 @@ def test_tdm_substate_matches_global_circuit():
 
     torch.testing.assert_close(actual_cov, expected_cov[:, indices[:, None], indices])
     torch.testing.assert_close(actual_mean, expected_mean[:, indices])
+
+
+def test_encoded_tdm_substate_matches_global_circuit():
+    circuit = dq.QumodeCircuit(2, init_state='vac', backend='gaussian')
+    circuit.s(0, encode=True)
+    circuit.bs([0, 1], encode=True)
+    circuit.delay(0, ntau=2, convention='mzi', encode=True)
+    circuit.delay(1, ntau=3, inputs=[0.5, -0.1], convention='mzi')
+    circuit.to(torch.double)
+    nstep = 4
+    time_steps = torch.tensor([1, 3])
+    wires = torch.tensor([1, 0])
+    data = torch.linspace(-0.3, 0.6, 2 * nstep * circuit.ndata, dtype=torch.double).reshape(2, -1)
+    data.requires_grad_()
+    state_before = {name: value.clone() for name, value in circuit.state_dict().items()}
+
+    actual_cov, actual_mean = circuit.tdm_substate(nstep, time_steps, wires, data)
+    for name, value in state_before.items():
+        torch.testing.assert_close(circuit.state_dict()[name], value)
+    global_circuit = circuit.global_circuit(nstep)
+    global_circuit.to(torch.double)
+    expected_cov, expected_mean = global_circuit(data)
+    output_wires = circuit.tdm_output_wires(nstep)[time_steps][:, wires].reshape(-1)
+    indices = torch.cat([output_wires, output_wires + global_circuit.nmode])
+
+    torch.testing.assert_close(actual_cov, expected_cov[:, indices[:, None], indices])
+    torch.testing.assert_close(actual_mean, expected_mean[:, indices])
+    actual_grad = torch.autograd.grad(actual_cov.square().sum(), data)[0]
+    expected_grad = torch.autograd.grad(expected_cov[:, indices[:, None], indices].square().sum(), data)[0]
+    torch.testing.assert_close(actual_grad, expected_grad)
+    single_cov, single_mean = circuit.tdm_substate(nstep, time_steps, wires, data[0])
+    torch.testing.assert_close(single_cov, actual_cov[:1])
+    torch.testing.assert_close(single_mean, actual_mean[:1])

--- a/tests/test_photonic_tdm.py
+++ b/tests/test_photonic_tdm.py
@@ -11,3 +11,26 @@ def test_tdm_output_wires():
     output_wires = circuit.tdm_output_wires(3)
 
     assert torch.equal(output_wires, torch.tensor([[2, 6], [7, 8], [9, 10]]))
+
+
+def test_tdm_substate_matches_global_circuit():
+    circuit = dq.QumodeCircuit(2, init_state='vac', backend='gaussian')
+    circuit.s(0, r=0.2)
+    circuit.bs([0, 1], [0.3, 0.1])
+    circuit.delay(0, ntau=2, inputs=[0.4, 0.2], convention='mzi')
+    circuit.delay(1, ntau=3, inputs=[0.5, -0.1], convention='mzi')
+    circuit.loss_db(0, 0.2)
+    circuit.to(torch.double)
+    nstep = 5
+    time_steps = torch.tensor([1, 3, 4])
+    wires = torch.tensor([1, 0])
+
+    actual_cov, actual_mean = circuit.tdm_substate(nstep, time_steps, wires)
+    global_circuit = circuit.global_circuit(nstep)
+    global_circuit.to(torch.double)
+    expected_cov, expected_mean = global_circuit()
+    output_wires = circuit.tdm_output_wires(nstep)[time_steps][:, wires].reshape(-1)
+    indices = torch.cat([output_wires, output_wires + global_circuit.nmode])
+
+    torch.testing.assert_close(actual_cov, expected_cov[:, indices[:, None], indices])
+    torch.testing.assert_close(actual_mean, expected_mean[:, indices])


### PR DESCRIPTION
## Summary

- add lightweight `tdm_output_wires` and `tdm_substate` APIs for selected Gaussian TDM outputs, including batched encoded data
- support multiple final-state patterns in Gaussian `get_prob`, with fixed-total validation for PNRD and threshold detection
- reduce click-counting Kensingtonian inputs to occupied modes and batch permutation-equivalent patterns

## Examples

Get output-mode indices without building the global circuit, or directly construct a selected Gaussian TDM substate:

```python
import torch
import deepquantum as dq

circuit = dq.QumodeCircuit(2, init_state='vac', backend='gaussian')
circuit.s(0, r=0.2)
circuit.delay(0, ntau=2, inputs=[0.4, 0.2], convention='mzi')
circuit.delay(1, ntau=3, inputs=[0.5, -0.1], convention='mzi')
circuit.to(torch.double)

output_wires = circuit.tdm_output_wires(5)  # shape: (5, 2)
cov, mean = circuit.tdm_substate(
    nstep=5,
    time_steps=[1, 3, 4],
    wires=[0, 1],
)
# cov: (1, 12, 12), mean: (1, 12, 1)
```

Compute several click-pattern probabilities in one call:

```python
circuit = dq.QumodeCircuit(
    2, init_state='vac', cutoff=3, backend='gaussian', detector='click'
)
circuit.s(0, r=0.3)
circuit.bs([0, 1], [0.4, 0.2])
circuit.to(torch.double)

state = circuit()
patterns = torch.tensor([[0, 0], [1, 0], [0, 1], [1, 1]])
probs = circuit.get_prob(patterns, state)  # shape: (4,)

state_batch = [
    state[0].expand(2, -1, -1),
    state[1].expand(2, -1, -1),
]
probs_batch = circuit.get_prob(patterns, state_batch)  # shape: (2, 4)
```

For PNRD and threshold detection, patterns passed in one call must have the same total occupation.